### PR TITLE
docs: clarify DNS settings help text

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/dns/DnsSettingsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/dns/DnsSettingsScreen.kt
@@ -51,7 +51,7 @@ fun DnsSettingsScreen(viewModel: DnsViewModel = koinViewModel()) {
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
     ) {
         Column {
-            GroupLabel(stringResource(R.string.endpoint_resolution), Modifier.padding(horizontal = 16.dp))
+            GroupLabel(stringResource(R.string.endpoint), Modifier.padding(horizontal = 16.dp))
             LabelledDropdown(
                 title = stringResource(R.string.dns_protocol),
                 description = { DescriptionText(stringResource(R.string.dns_endpoint_section_description)) },

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/dns/DnsSettingsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/dns/DnsSettingsScreen.kt
@@ -30,6 +30,7 @@ import com.zaneschepke.wireguardautotunnel.ui.common.button.SurfaceRow
 import com.zaneschepke.wireguardautotunnel.ui.common.button.SwitchWithDivider
 import com.zaneschepke.wireguardautotunnel.ui.common.dropdown.LabelledDropdown
 import com.zaneschepke.wireguardautotunnel.ui.common.label.GroupLabel
+import com.zaneschepke.wireguardautotunnel.ui.common.text.DescriptionText
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route
 import com.zaneschepke.wireguardautotunnel.util.extensions.capitalize
 import com.zaneschepke.wireguardautotunnel.viewmodel.DnsViewModel
@@ -50,9 +51,10 @@ fun DnsSettingsScreen(viewModel: DnsViewModel = koinViewModel()) {
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
     ) {
         Column {
-            GroupLabel(stringResource(R.string.endpoint), Modifier.padding(horizontal = 16.dp))
+            GroupLabel(stringResource(R.string.endpoint_resolution), Modifier.padding(horizontal = 16.dp))
             LabelledDropdown(
                 title = stringResource(R.string.dns_protocol),
+                description = { DescriptionText(stringResource(R.string.dns_endpoint_section_description)) },
                 leading = { Icon(Icons.Outlined.Dns, contentDescription = null) },
                 currentValue = dnsUiState.dnsSettings.dnsProtocol,
                 onSelected = { selected -> selected?.let { viewModel.setDnsProtocol(it) } },
@@ -82,6 +84,7 @@ fun DnsSettingsScreen(viewModel: DnsViewModel = koinViewModel()) {
                     Icon(ImageVector.vectorResource(R.drawable.host), contentDescription = null)
                 },
                 title = stringResource(R.string.global_dns_servers),
+                description = { DescriptionText(stringResource(R.string.global_dns_description)) },
                 trailing = { modifier ->
                     SwitchWithDivider(
                         checked = dnsUiState.dnsSettings.isGlobalTunnelDnsEnabled,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,7 +304,6 @@
     <string name="http_bind_address">HTTP bind address</string>
     <string name="defaults_to_template">(defaults to %1$s)</string>
     <string name="dns_settings">DNS settings</string>
-    <string name="endpoint_resolution">Endpoint resolution</string>
     <string name="dns_endpoint_section_description">Only used to resolve the VPN server address before connecting. Does not affect DNS used once tunnel is active.</string>
     <string name="global_dns_description">Enable to override each tunnel\'s DNS. Tap to set IP addresses in the global config.</string>
     <string name="locked_down">Locked down</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,6 +304,9 @@
     <string name="http_bind_address">HTTP bind address</string>
     <string name="defaults_to_template">(defaults to %1$s)</string>
     <string name="dns_settings">DNS settings</string>
+    <string name="endpoint_resolution">Endpoint resolution</string>
+    <string name="dns_endpoint_section_description">Only used to resolve the VPN server address before connecting. Does not affect DNS used once tunnel is active.</string>
+    <string name="global_dns_description">Override each tunnel\'s DNS with IP addresses from the global config</string>
     <string name="locked_down">Locked down</string>
     <string name="dns_provider">DNS provider</string>
     <string name="dns_protocol">DNS protocol</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,7 +306,7 @@
     <string name="dns_settings">DNS settings</string>
     <string name="endpoint_resolution">Endpoint resolution</string>
     <string name="dns_endpoint_section_description">Only used to resolve the VPN server address before connecting. Does not affect DNS used once tunnel is active.</string>
-    <string name="global_dns_description">Override each tunnel\'s DNS with IP addresses from the global config</string>
+    <string name="global_dns_description">Enable to override each tunnel\'s DNS. Tap to set IP addresses in the global config.</string>
     <string name="locked_down">Locked down</string>
     <string name="dns_provider">DNS provider</string>
     <string name="dns_protocol">DNS protocol</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,7 +305,7 @@
     <string name="defaults_to_template">(defaults to %1$s)</string>
     <string name="dns_settings">DNS settings</string>
     <string name="dns_endpoint_section_description">Only used to resolve the VPN server address before connecting. Does not affect DNS used once tunnel is active.</string>
-    <string name="global_dns_description">Enable to override each tunnel\'s DNS. Tap to set IP addresses in the global config.</string>
+    <string name="global_dns_description">Enable to override each tunnel\'s DNS. Tap to set IPs once enabled.</string>
     <string name="locked_down">Locked down</string>
     <string name="dns_provider">DNS provider</string>
     <string name="dns_protocol">DNS protocol</string>


### PR DESCRIPTION
The DNS settings page had no descriptions, so it's easy to think the endpoint resolution options (protocol, provider) control DNS while the tunnel is active. They only affect how WG Tunnel resolves the peer endpoint address before connecting. The Global DNS servers row also isn't obvious about needing to enable the toggle before you can tap to configure IPs. Added descriptions to both sections to clarify their purpose and usage.

Screenshot:
<img width="309" height="249" alt="Screenshot 2026-02-18 at 7 05 07 PM" src="https://github.com/user-attachments/assets/717a1ad2-4a17-4b65-bfc6-19747e0e5c20" />

