### PR TITLE
fix(service): prevent notification flickering when auto-tunnel is active

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/service/BaseTunnelForegroundService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/service/BaseTunnelForegroundService.kt
@@ -119,15 +119,19 @@ abstract class BaseTunnelForegroundService : LifecycleService(), TunnelService {
 
         statsJob =
             lifecycleScope.launch(ioDispatcher) {
+                var lastTraffic: Pair<Long, Long>? = null
                 while (isActive) {
                     val traffic = readTraffic(single.id)
-
-                    notificationManager.show(
-                        NotificationManager.VPN_NOTIFICATION_ID,
-                        createTunnelNotification(single, consumedTraffic = traffic),
-                    )
-
-                    delay(1000)
+                    if (traffic != lastTraffic) {
+                        lastTraffic = traffic
+                        ServiceCompat.startForeground(
+                            this@BaseTunnelForegroundService,
+                            NotificationManager.VPN_NOTIFICATION_ID,
+                            createTunnelNotification(single, consumedTraffic = traffic),
+                            fgsType,
+                        )
+                    }
+                    delay(5000)
                 }
             }
     }
@@ -171,7 +175,7 @@ abstract class BaseTunnelForegroundService : LifecycleService(), TunnelService {
         statsJob = null
         currentSingleTunnelId = null
 
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
         Timber.d("onDestroy")
         super.onDestroy()
     }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/service/autotunnel/AutoTunnelService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/service/autotunnel/AutoTunnelService.kt
@@ -113,12 +113,13 @@ class AutoTunnelService : LifecycleService() {
     }
 
     fun stop() {
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 
     override fun onDestroy() {
         serviceManager.handleAutoTunnelServiceDestroy()
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary

Fix two issues causing the "Tunnel running" notification (ID 100) to flicker visually when auto-tunnel is active (I have Android 16).

## Problem

When both the VPN notification (ID 100) and the auto-tunnel notification (ID 122) are visible in the notification shade simultaneously:

1. **Race condition on service lifecycle**: `onDestroy()` in `AutoTunnelService` and `BaseTunnelForegroundService` called `STOP_FOREGROUND_REMOVE`, which globally cancels the notification ID. During a rapid stop/start cycle (e.g. network transition), this could remove a notification already posted by the newly started service instance, causing Android 16 to kill the foreground service that lost its notification.

2. **Notification drawer flicker**: The `statsJob` updated the VPN notification every second via `NotificationManager.notify()`. Each update triggers a full re-layout of the notification shade. With two stacked notifications from the same app, this causes both to visually jump every second.

## Solution

- Changed `onDestroy()` in both services to use `STOP_FOREGROUND_DETACH` instead of `STOP_FOREGROUND_REMOVE`. The intentional stop path (`stop()`) still uses `STOP_FOREGROUND_REMOVE` before `stopSelf()` to cleanly remove the notification.
- Switched `statsJob` from `NotificationManager.notify()` to `ServiceCompat.startForeground()` (correct API for updating a foreground service notification).
- Only update the notification when traffic stats actually change (skip re-layouts during idle periods).
- Reduced the stats poll interval from 1s to 5s.

## Technical Design

**Files changed:**
- `AutoTunnelService.kt`: Added `STOP_FOREGROUND_REMOVE` in `stop()` before `stopSelf()`; changed `onDestroy()` to `STOP_FOREGROUND_DETACH`.
- `BaseTunnelForegroundService.kt`: Changed `onDestroy()` to `STOP_FOREGROUND_DETACH`; refactored `statsJob` to use `startForeground()`, conditional updates, and 5s interval.

**Before / After (`statsJob`):**
```kotlin
// Before
notificationManager.show(VPN_NOTIFICATION_ID, notification)
delay(1000)

// After
var lastTraffic: Pair<Long, Long>? = null
if (traffic != lastTraffic) {
    lastTraffic = traffic
    ServiceCompat.startForeground(this@..., VPN_NOTIFICATION_ID, notification, fgsType)
}
delay(5000)
```

## Test Plan

- [x] Auto-tunnel active + tunnel running → both notifications visible → no flickering at rest
- [x] Active traffic → notification updates at most every 5s, no jarring jump
- [x] Tunnel idle (no traffic) → zero notification updates
- [x] Disable auto-tunnel → VPN notification disappears cleanly
- [x] Network transition with auto-tunnel → stop/start cycle completes without leaving a stale notification