### PR TITLE
fix(ping): transmitted always 0 when all pings fail (timeout)

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/network/NetworkUtils.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/network/NetworkUtils.kt
@@ -62,8 +62,8 @@ class NetworkUtils(private val ioDispatcher: CoroutineDispatcher) {
                     }
                     .collect()
 
+                stats.transmitted = count
                 if (rttList.isNotEmpty()) {
-                    stats.transmitted = count
                     stats.received = received
                     stats.packetLoss = ((count - received).toDouble().round(2) / count) * 100
                     stats.rttMin = rttList.minOrNull()?.round(2) ?: 0.0


### PR DESCRIPTION
## Summary

- `pingWithStats()` only assigned `stats.transmitted = count` inside the `if (rttList.isNotEmpty())` block
- When all pings fail (timeout -> `Icmp.PingResult.Failed`), `rttList` stays empty -> `transmitted` stays at 0
- `HandshakeRestartHandler.awaitPingFailures()` (introduced in #1182) requires `transmitted > 0` to distinguish a real failure from pings not routed through the tunnel -> restart was never triggered

**Fix**: move `stats.transmitted = count` before the `if` block so it always reflects the number of attempted pings.

Before: `transmitted=0, received=0, isReachable=false` on full timeout
After: `transmitted=count, received=0, isReachable=false` on full timeout

## Test plan

- [x] Deliberately break a tunnel (invalid endpoint or block ICMP) -> ping timeouts -> `transmitted=count` in PingStats -> auto-restart triggers after configured failure count
- [x] Working tunnel -> pings succeed -> `transmitted=count, received=count` unchanged

