### PR TITLE
fix: show tunnel name in collapsed notification title

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/notification/AndroidTunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/notification/AndroidTunnelNotificationService.kt
@@ -55,10 +55,16 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
                 )
             }
 
+        // Show the tunnel name as the title when a single tunnel is active so it remains
+        // visible in the collapsed notification; fall back to the generic channel name otherwise.
         val title =
-            when (channel) {
-                is NotificationChannels.Tunnel.VPN -> context.getString(R.string.vpn)
-                is NotificationChannels.Tunnel.Proxy -> context.getString(R.string.proxy)
+            if (tunnelNotificationLines.size == 1) {
+                tunnelNotificationLines.values.first().name
+            } else {
+                when (channel) {
+                    is NotificationChannels.Tunnel.VPN -> context.getString(R.string.vpn)
+                    is NotificationChannels.Tunnel.Proxy -> context.getString(R.string.proxy)
+                }
             }
 
         val style =


### PR DESCRIPTION
Fixes #1273

Restores the pre-v5 behavior where the active tunnel's name was shown
in the notification title. When a single tunnel is active, the title now
uses the tunnel name so it stays visible when the notification is collapsed.
Multiple grouped tunnels keep the generic VPN/Proxy title.
