### PR TITLE
feat: extended dns resolver

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,6 +194,13 @@ androidComponents {
     }
 }
 
+tasks.configureEach {
+    if (name.matches(Regex("merge.*(JniLib|NativeLib).*"))) {
+        val tunnelCopy = project(":tunnel").tasks.matching { it.name.matches(Regex("copy.*JniLibsProjectOnly")) }
+        dependsOn(tunnelCopy)
+    }
+}
+
 dependencies {
     implementation(project(":logcatter"))
     implementation(project(":networkmonitor"))

--- a/app/schemas/com.zaneschepke.wireguardautotunnel.data.AppDatabase/33.json
+++ b/app/schemas/com.zaneschepke.wireguardautotunnel.data.AppDatabase/33.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 33,
-    "identityHash": "ee80bf85dda32c6d9e8f24568459f000",
+    "identityHash": "318fbf30e6953cd25926f071e821f80b",
     "entities": [
       {
         "tableName": "tunnel_config",
@@ -184,7 +184,7 @@
       },
       {
         "tableName": "general_settings",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_shortcuts_enabled` INTEGER NOT NULL DEFAULT 0, `is_restore_on_boot_enabled` INTEGER NOT NULL DEFAULT 0, `is_multi_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `global_split_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `app_mode` INTEGER NOT NULL DEFAULT 0, `theme` TEXT NOT NULL DEFAULT 'AUTOMATIC', `locale` TEXT, `remote_key` TEXT, `is_remote_control_enabled` INTEGER NOT NULL DEFAULT 0, `is_pin_lock_enabled` INTEGER NOT NULL DEFAULT 0, `is_always_on_vpn_enabled` INTEGER NOT NULL DEFAULT 0, `already_donated` INTEGER NOT NULL DEFAULT 0, `screen_recording_security` INTEGER NOT NULL DEFAULT 1, `global_amnezia_enabled` INTEGER NOT NULL DEFAULT 0, `tunnel_scripting_enabled` INTEGER NOT NULL DEFAULT 0, `seamless_roaming_enabled` INTEGER NOT NULL DEFAULT 0)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_shortcuts_enabled` INTEGER NOT NULL DEFAULT 0, `is_restore_on_boot_enabled` INTEGER NOT NULL DEFAULT 0, `is_multi_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `global_split_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `app_mode` INTEGER NOT NULL DEFAULT 0, `theme` TEXT NOT NULL DEFAULT 'AUTOMATIC', `locale` TEXT, `remote_key` TEXT, `is_remote_control_enabled` INTEGER NOT NULL DEFAULT 0, `is_pin_lock_enabled` INTEGER NOT NULL DEFAULT 0, `is_always_on_vpn_enabled` INTEGER NOT NULL DEFAULT 0, `already_donated` INTEGER NOT NULL DEFAULT 0, `screen_recording_security` INTEGER NOT NULL DEFAULT 1, `global_amnezia_enabled` INTEGER NOT NULL DEFAULT 0, `tunnel_scripting_enabled` INTEGER NOT NULL DEFAULT 0, `seamless_roaming_enabled` INTEGER NOT NULL DEFAULT 0, `is_extended_dns_enabled` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -296,6 +296,13 @@
           {
             "fieldPath": "seamlessRoamingEnabled",
             "columnName": "seamless_roaming_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isExtendedDnsEnabled",
+            "columnName": "is_extended_dns_enabled",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -528,7 +535,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ee80bf85dda32c6d9e8f24568459f000')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '318fbf30e6953cd25926f071e821f80b')"
     ]
   }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/orchestration/TunnelCoordinator.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/orchestration/TunnelCoordinator.kt
@@ -1,9 +1,9 @@
 package com.zaneschepke.wireguardautotunnel.core.orchestration
 
 import com.zaneschepke.tunnel.model.BackendMode
+import com.zaneschepke.tunnel.model.ExtendedDnsConfig
 import com.zaneschepke.wireguardautotunnel.core.event.TunnelErrorEvent
 import com.zaneschepke.wireguardautotunnel.core.tunnel.TunnelProvider
-import com.zaneschepke.wireguardautotunnel.data.repository.RoomDnsSettingsRepository
 import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelActionSource
 import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelMode
 import com.zaneschepke.wireguardautotunnel.domain.events.TunnelActionEvent
@@ -13,6 +13,7 @@ import com.zaneschepke.wireguardautotunnel.domain.model.LockdownSettings
 import com.zaneschepke.wireguardautotunnel.domain.model.MonitoringSettings
 import com.zaneschepke.wireguardautotunnel.domain.model.ProxySettings
 import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
+import com.zaneschepke.wireguardautotunnel.domain.repository.DnsSettingsRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.GeneralSettingRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.LockdownSettingsRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.MonitoringSettingsRepository
@@ -43,7 +44,7 @@ class TunnelCoordinator(
     private val bootstrapCoordinator: AppBoostrapCoordinator,
     settingsRepository: GeneralSettingRepository,
     private val tunnelRepository: TunnelRepository,
-    dnsSettingsRepository: RoomDnsSettingsRepository,
+    dnsSettingsRepository: DnsSettingsRepository,
     monitoringSettingsRepository: MonitoringSettingsRepository,
     proxyRepository: ProxySettingsRepository,
     lockdownModeRepository: LockdownSettingsRepository,
@@ -184,7 +185,10 @@ class TunnelCoordinator(
                         return
                     }
 
-                    BackendMode.Vpn(runConfig)
+                    BackendMode.Vpn(
+                            runConfig,
+                            extendedDns = if (snapshot.general.isExtendedDnsEnabled) ExtendedDnsConfig(systemDnsServers = "") else null,
+                        )
                 }
 
                 TunnelMode.PROXY -> {

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/dao/GeneralSettingsDao.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/dao/GeneralSettingsDao.kt
@@ -37,4 +37,7 @@ interface GeneralSettingsDao {
 
     @Query("UPDATE general_settings SET seamless_roaming_enabled = :enabled")
     suspend fun updateSeamlessRoaming(enabled: Boolean)
+
+    @Query("UPDATE general_settings SET is_extended_dns_enabled = :enabled")
+    suspend fun updateExtendedDnsEnabled(enabled: Boolean)
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/GeneralSettings.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/GeneralSettings.kt
@@ -36,4 +36,7 @@ data class GeneralSettings(
     val tunnelScriptingEnabled: Boolean = true,
     @ColumnInfo(name = "seamless_roaming_enabled", defaultValue = "0")
     val seamlessRoamingEnabled: Boolean = true,
+
+    @ColumnInfo(name = "is_extended_dns_enabled", defaultValue = "0")
+    val isExtendedDnsEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/SettingsMapper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/SettingsMapper.kt
@@ -23,6 +23,7 @@ fun Entity.toDomain(): Domain =
         isGlobalAmneziaEnabled = isGlobalAmneziaEnabled,
         tunnelScriptingEnabled = tunnelScriptingEnabled,
         seamlessRoamingEnabled = seamlessRoamingEnabled,
+        isExtendedDnsEnabled = isExtendedDnsEnabled,
     )
 
 fun Domain.toEntity(): Entity =
@@ -44,4 +45,5 @@ fun Domain.toEntity(): Entity =
         isGlobalAmneziaEnabled = isGlobalAmneziaEnabled,
         tunnelScriptingEnabled = tunnelScriptingEnabled,
         seamlessRoamingEnabled = seamlessRoamingEnabled,
+        isExtendedDnsEnabled = isExtendedDnsEnabled,
     )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/RoomSettingsRepository.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/RoomSettingsRepository.kt
@@ -49,4 +49,8 @@ class RoomSettingsRepository(private val settingsDao: GeneralSettingsDao) :
     override suspend fun updateSeamlessRoaming(enabled: Boolean) {
         settingsDao.updateSeamlessRoaming(enabled)
     }
+
+    override suspend fun updateExtendedDnsEnabled(enabled: Boolean) {
+        settingsDao.updateExtendedDnsEnabled(enabled)
+    }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/GeneralSettings.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/GeneralSettings.kt
@@ -22,4 +22,5 @@ data class GeneralSettings(
     val isGlobalAmneziaEnabled: Boolean = false,
     val tunnelScriptingEnabled: Boolean = false,
     val seamlessRoamingEnabled: Boolean = false,
+    val isExtendedDnsEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/repository/GeneralSettingRepository.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/repository/GeneralSettingRepository.kt
@@ -25,4 +25,6 @@ interface GeneralSettingRepository {
     suspend fun updateScreenRecordingSecurity(enabled: Boolean)
 
     suspend fun updateSeamlessRoaming(enabled: Boolean)
+
+    suspend fun updateExtendedDnsEnabled(enabled: Boolean)
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/globals/TunnelGlobalsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/globals/TunnelGlobalsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.CallSplit
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Dns
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelMode
 import com.zaneschepke.wireguardautotunnel.ui.LocalNavController
 import com.zaneschepke.wireguardautotunnel.ui.common.button.SurfaceRow
 import com.zaneschepke.wireguardautotunnel.ui.common.button.SwitchWithDivider
+import com.zaneschepke.wireguardautotunnel.ui.common.button.ThemedSwitch
 import com.zaneschepke.wireguardautotunnel.ui.common.text.DescriptionText
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route
 import com.zaneschepke.wireguardautotunnel.ui.theme.Disabled
@@ -88,6 +90,20 @@ fun TunnelGlobalsScreen(
                     navController.push(Route.ConfigGlobal(id = it.id))
                 }
             },
+        )
+        SurfaceRow(
+            leading = { Icon(Icons.Outlined.Dns, contentDescription = null) },
+            title = stringResource(R.string.extended_dns_title),
+            trailing = {
+                ThemedSwitch(
+                    checked = uiState.settings.isExtendedDnsEnabled,
+                    onClick = viewModel::setExtendedDnsEnabled,
+                )
+            },
+            description = {
+                DescriptionText(stringResource(R.string.extended_dns_description))
+            },
+            onClick = { viewModel.setExtendedDnsEnabled(!uiState.settings.isExtendedDnsEnabled) },
         )
     }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/ConfigEditViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/ConfigEditViewModel.kt
@@ -127,16 +127,20 @@ class ConfigEditViewModel(
 
         runCatching {
                 val config = state.draft.config.buildConfig(state.draft.tunnelName)
-
-                config.validate()
-
-                val quickConfig = config.asQuickString()
+                val sanitizedDns =
+                    config.`interface`.dns
+                        ?.split(",")
+                        ?.map { it.trim() }
+                        ?.filter { !it.startsWith("~") }
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.joinToString(", ")
+                config.copy(`interface` = config.`interface`.copy(dns = sanitizedDns)).validate()
 
                 val tunnelConfig =
                     if (tunnelId == null) {
-                        TunnelConfig.tunnelConfFromQuick(quickConfig, state.draft.tunnelName)
+                        TunnelConfig.tunnelConfFromQuick(config.asQuickString(), state.draft.tunnelName)
                     } else {
-                        state.tunnel?.copy(name = state.draft.tunnelName, quickConfig = quickConfig)
+                        state.tunnel?.copy(name = state.draft.tunnelName, quickConfig = config.asQuickString())
                     }
 
                 tunnelConfig?.let {
@@ -153,12 +157,24 @@ class ConfigEditViewModel(
                         tunnelCoordinator.startTunnel(it)
                     }
 
-                    postSideEffect(
-                        GlobalSideEffect.Snackbar(
-                            StringValue.StringResource(R.string.config_changes_saved),
-                            ToastType.Success,
+                    val hasExtendedDnsEntries =
+                        state.draft.config.`interface`.dnsServers
+                            .split(",").any { it.trim().startsWith("~") }
+                    if (hasExtendedDnsEntries && !settingsRepository.getGeneralSettings().isExtendedDnsEnabled) {
+                        postSideEffect(
+                            GlobalSideEffect.Snackbar(
+                                StringValue.StringResource(R.string.config_changes_saved_extended_dns_without_effect),
+                                ToastType.Info,
+                            )
                         )
-                    )
+                    } else {
+                        postSideEffect(
+                            GlobalSideEffect.Snackbar(
+                                StringValue.StringResource(R.string.config_changes_saved),
+                                ToastType.Success,
+                            )
+                        )
+                    }
 
                     postSideEffect(GlobalSideEffect.PopBackStack)
                 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt
@@ -123,4 +123,16 @@ class SettingsViewModel(
     fun setAlreadyDonated(to: Boolean) = intent {
         settingsRepository.upsert(state.settings.copy(alreadyDonated = to))
     }
+
+    fun setExtendedDnsEnabled(enabled: Boolean) = intent {
+        settingsRepository.upsert(state.settings.copy(isExtendedDnsEnabled = enabled))
+        if (enabled) {
+            postSideEffect(
+                GlobalSideEffect.Snackbar(
+                    StringValue.StringResource(R.string.extended_dns_ipv6_not_supported),
+                    ToastType.Warning,
+                )
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
@@ -252,10 +252,24 @@ class SharedAppViewModel(
 
     fun importTunnelConfigs(configs: Map<QuickConfig, TunnelName>) = intent {
         try {
+            val hasExtendedDnsEntries =
+                configs.keys.any { config ->
+                    config.lines().any { line ->
+                        line.trimStart().startsWith("DNS =") && line.contains("~")
+                    }
+                }
             val tunnelConfigs = configs.map { (config, name) ->
                 TunnelConfig.tunnelConfFromQuick(config, name)
             }
             tunnelRepository.saveTunnelsUniquely(tunnelConfigs, state.tunnelNames.map { it.value })
+            if (hasExtendedDnsEntries && !settingsRepository.getGeneralSettings().isExtendedDnsEnabled) {
+                postSideEffect(
+                    GlobalSideEffect.Snackbar(
+                        StringValue.StringResource(R.string.config_changes_saved_extended_dns_without_effect),
+                        ToastType.Info,
+                    )
+                )
+            }
         } catch (e: Exception) {
             if (e is ConfigParseException) {
                 postSideEffect(GlobalSideEffect.Snackbar(e.asStringValue(), ToastType.Error))
@@ -373,8 +387,20 @@ class SharedAppViewModel(
 
     fun copySelectedTunnel() = intent {
         val selected = tunnelsUiState.value.selectedTunnels.firstOrNull() ?: return@intent
+        val hasExtendedDnsEntries =
+            selected.quickConfig.lines().any { line ->
+                line.trimStart().startsWith("DNS =") && line.contains("~")
+            }
         val copy = TunnelConfig.tunnelConfFromQuick(selected.quickConfig, selected.name)
         tunnelRepository.saveTunnelsUniquely(listOf(copy), state.tunnelNames.map { it.value })
+        if (hasExtendedDnsEntries && !settingsRepository.getGeneralSettings().isExtendedDnsEnabled) {
+            postSideEffect(
+                GlobalSideEffect.Snackbar(
+                    StringValue.StringResource(R.string.config_changes_saved_extended_dns_without_effect),
+                    ToastType.Info,
+                )
+            )
+        }
         clearSelectedTunnels()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="exclude">Exclude</string>
     <string name="include">Include</string>
     <string name="config_changes_saved">Configuration changes saved.</string>
+    <string name="config_changes_saved_extended_dns_without_effect">Subdomain matching rules have no effect until extended DNS resolver is enabled. Configuration changes saved.</string>
     <string name="public_key">Public key</string>
     <string name="addresses">Addresses</string>
     <string name="dns_servers">DNS servers</string>
@@ -404,6 +405,8 @@
     <string name="toggle_sensitive_data_visibility">Toggle sensitive data visibility</string>
     <string name="ipv6_settings">IPv6 settings</string>
     <string name="automation">Automation</string>
+    <string name="extended_dns_title">Extended DNS resolver</string>
+    <string name="extended_dns_description">Intercept DNS queries and route them based on match rules configured in the tunnel config</string>
     <string name="peer_resolution">Peer Resolution</string>
     <string name="resolution_method">Resolution method</string>
     <string name="dot">DNS over TLS (DoT)</string>
@@ -422,6 +425,8 @@
     <string name="private_dns_hostname">Private DNS: hostname (%1$s)</string>
     <string name="system_dns_servers">Servers: %1$s</string>
     <string name="no_system_dns_detected">No system DNS detected</string>
+    <string name="private_dns_warning">Private DNS is active. Extended DNS resolver may not intercept DNS queries when Private DNS is enabled.</string>
+    <string name="extended_dns_ipv6_not_supported">IPv6 is not supported when Extended DNS resolver is enabled</string>
     <!-- Tunnel states -->
     <string name="tunnel_state_connected">Connected</string>
     <string name="tunnel_state_resolving_dns">Resolving DNS</string>

--- a/tunnel/build.gradle.kts
+++ b/tunnel/build.gradle.kts
@@ -55,6 +55,17 @@ android {
     }
 }
 
+tasks.matching { it.name.startsWith("buildCMake") }.configureEach {
+    doFirst {
+        delete(fileTree(layout.buildDirectory.dir("intermediates/library_jni")) { include("**/libam-go.so") })
+        delete(fileTree(layout.buildDirectory.dir("intermediates/merged_native_libs")) { include("**/libam-go.so") })
+    }
+}
+
+tasks.matching { it.name.contains("JniLib") || it.name.contains("NativeLib") }.configureEach {
+    dependsOn(tasks.matching { it.name.startsWith("buildCMake") })
+}
+
 dependencies {
     implementation(project(":hevtunnel"))
     api(project(":pinger"))

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/VpnBackend.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/VpnBackend.kt
@@ -19,9 +19,11 @@ internal object VpnBackend {
 
     external fun awgTriggerBindUpdate(handle: Int)
 
-    external fun awgTurnOn(ifName: String, tunFd: Int, settings: String, uapiPath: String): Int
+    external fun awgTurnOn(ifName: String, tunFd: Int, settings: String, uapiPath: String, systemDnsServers: String): Int
 
     external fun awgUpdateTunnelPeers(handle: Int, settings: String): Int
+
+    external fun awgUpdateSystemDns(handle: Int, systemDnsServers: String): Int
 
     external fun awgVersion(): String
 }

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelBackend.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelBackend.kt
@@ -1,5 +1,8 @@
 package com.zaneschepke.tunnel.backend
 
+import android.content.Context
+import android.net.ConnectivityManager
+import java.net.Inet4Address
 import com.zaneschepke.networkmonitor.ActiveNetwork
 import com.zaneschepke.networkmonitor.StableNetworkEngine
 import com.zaneschepke.tunnel.ApplicationProvider
@@ -14,8 +17,8 @@ import com.zaneschepke.tunnel.model.DnsBootstrapResult
 import com.zaneschepke.tunnel.model.Host
 import com.zaneschepke.tunnel.model.KillSwitchConfig
 import com.zaneschepke.tunnel.model.PublicKey
-import com.zaneschepke.tunnel.service.ServiceHolder
 import com.zaneschepke.tunnel.service.VpnService
+import com.zaneschepke.tunnel.service.ServiceHolder
 import com.zaneschepke.tunnel.state.ActiveTunnel
 import com.zaneschepke.tunnel.state.BackendStatus
 import com.zaneschepke.tunnel.state.BootstrapState
@@ -137,18 +140,29 @@ class TunnelBackend(
                     if (scriptsEnabled)
                         mode.config.`interface`.preUp?.let { runScripts(it, tunnel.id) }
 
-                    setupServiceForMode(tunnel, mode)
+                    val effectiveMode =
+                        if (mode is BackendMode.Vpn && mode.extendedDns != null) {
+                            mode.copy(extendedDns = mode.extendedDns.copy(systemDnsServers = getSystemDnsServers()))
+                        } else {
+                            mode
+                        }
 
-                    if (hasDynamicEndpoints(mode)) {
-                        pendingResolutionJobs[tunnel.id] = startTunnelBootstrapJob(tunnel, mode)
+                    setupServiceForMode(tunnel, effectiveMode)
+
+                    if (hasDynamicEndpoints(effectiveMode)) {
+                        pendingResolutionJobs[tunnel.id] =
+                            startTunnelBootstrapJob(tunnel, effectiveMode)
                     } else {
-                        val result = engine.start(tunnel, mode)
+                        val result = engine.start(tunnel, effectiveMode)
                         onEngineStartResult(tunnel.id, result)
 
                         if (scriptsEnabled) {
-                            mode.config.`interface`.postUp?.let { runScripts(it, tunnel.id) }
+                            effectiveMode.config.`interface`.postUp?.let {
+                                runScripts(it, tunnel.id)
+                            }
                         }
-                        tunnelJobs[tunnel.id] = startTunnelJobs(result.handle, tunnel, mode)
+                        tunnelJobs[tunnel.id] =
+                            startTunnelJobs(result.handle, tunnel, effectiveMode)
                     }
                 }
                 .onFailure { cleanup(tunnel.id) }
@@ -266,7 +280,11 @@ class TunnelBackend(
             }
             is BackendMode.Vpn -> {
                 val service = serviceHolder.ensureVpnProtectorRegistered()
-                service.createTunInterface(tunnel, mode.config)
+                service.createTunInterface(
+                    tunnel,
+                    mode.config,
+                    extendedDnsEnabled = mode.extendedDns != null,
+                )
             }
         }
     }
@@ -477,6 +495,10 @@ class TunnelBackend(
                     }
                 }
 
+                if (mode is BackendMode.Vpn && mode.extendedDns != null) {
+                    startExtendedDnsUpdateJob(handle, tunnel.id)
+                }
+
                 awaitCancellation()
             }
         }
@@ -516,6 +538,22 @@ class TunnelBackend(
                     delay(DDNS_MIN_CHECK_INTERVAL.milliseconds)
                 }
             }
+    }
+
+    private fun CoroutineScope.startExtendedDnsUpdateJob(handle: Int, tunnelId: Int) = launch {
+        var currentNetworkKey: String? = null
+
+        stableNetworkEngine.stableState.filterNotNull().collect { snapshot ->
+            val newKey = snapshot.key
+            if (newKey != currentNetworkKey) {
+                currentNetworkKey = newKey
+                val newDns = getSystemDnsServers()
+                if (newDns.isNotBlank()) {
+                    Timber.d("Network changed ($newKey), updating extended DNS fallback: $newDns")
+                    VpnBackend.awgUpdateSystemDns(handle, newDns)
+                }
+            }
+        }
     }
 
     private fun findEndpointMismatches(
@@ -756,6 +794,22 @@ class TunnelBackend(
             } else {
                 Timber.d("No mismatches found, skipping event emission.")
             }
+        }
+    }
+
+    private fun getSystemDnsServers(): String {
+        return try {
+            val cm =
+                serviceHolder.context.getSystemService(Context.CONNECTIVITY_SERVICE)
+                    as ConnectivityManager
+            val activeNetwork = cm.activeNetwork ?: return ""
+            val lp = cm.getLinkProperties(activeNetwork) ?: return ""
+            lp.dnsServers
+                .filter { it is Inet4Address && it.hostAddress !in VpnService.FAKE_DNS_IPS }
+                .joinToString(",") { it.hostAddress ?: "" }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to get system DNS servers")
+            ""
         }
     }
 

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/WireGuardTunnelEngine.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/WireGuardTunnelEngine.kt
@@ -57,7 +57,7 @@ internal class WireGuardTunnelEngine(private val serviceHolder: ServiceHolder) :
                 }
                 is BackendMode.Vpn -> {
                     val service = serviceHolder.getVpnService()
-                    startVpnTunnel(ifName, mode.config, service.detachVpnTunnelFd())
+                    startVpnTunnel(ifName, mode, service.detachVpnTunnelFd())
                 }
             }
 
@@ -136,11 +136,33 @@ internal class WireGuardTunnelEngine(private val serviceHolder: ServiceHolder) :
         VpnBackend.awgTurnOff(handle)
     }
 
-    private fun startVpnTunnel(ifName: String, config: Config, fd: Int?): Int {
+    private fun startVpnTunnel(ifName: String, mode: BackendMode.Vpn, fd: Int?): Int {
         val tunFd = fd ?: throw BackendException.Unauthorized("Failed to create tun interface")
 
+        val config =
+            if (mode.extendedDns == null) {
+                mode.config.copy(
+                    `interface` = mode.config.`interface`.copy(
+                        dns = mode.config.`interface`.dns
+                            ?.split(",")
+                            ?.map { it.trim() }
+                            ?.filter { !it.startsWith("~") }
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.joinToString(", ")
+                    )
+                )
+            } else {
+                mode.config
+            }
+
         val handle =
-            VpnBackend.awgTurnOn(ifName, tunFd, config.asQuickString(), serviceHolder.uapiPath)
+            VpnBackend.awgTurnOn(
+                ifName,
+                tunFd,
+                config.asQuickString(),
+                serviceHolder.uapiPath,
+                mode.extendedDns?.systemDnsServers ?: "",
+            )
         if (handle < 0) {
             throw BackendException.InternalError("Internal native error with code: $handle")
         }

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/model/BackendMode.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/model/BackendMode.kt
@@ -21,7 +21,10 @@ sealed class BackendMode {
         }
     }
 
-    data class Vpn(override val config: Config) : BackendMode() {
+    data class Vpn(
+        override val config: Config,
+        val extendedDns: ExtendedDnsConfig? = null,
+    ) : BackendMode() {
         override fun withConfig(config: Config) = copy(config = config)
     }
 }

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/model/ExtendedDnsConfig.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/model/ExtendedDnsConfig.kt
@@ -1,0 +1,3 @@
+package com.zaneschepke.tunnel.model
+
+data class ExtendedDnsConfig(val systemDnsServers: String)

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/service/VpnService.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/service/VpnService.kt
@@ -21,6 +21,7 @@ import com.zaneschepke.wireguardautotunnel.parser.Config
 import java.io.IOException
 import java.net.Inet4Address
 import java.net.Inet6Address
+import java.net.InetAddress
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
@@ -229,7 +230,7 @@ class VpnService : android.net.VpnService(), KillSwitch, SocketProtector {
         currentKillSwitchConfig = config
     }
 
-    fun createTunInterface(tunnel: Tunnel, config: Config) {
+    fun createTunInterface(tunnel: Tunnel, config: Config, extendedDnsEnabled: Boolean) {
         val intent = backend.applicationProvider.createVpnConfigurePendingIntent(this@VpnService)
         vpnTunFd?.close()
         vpnTunFd = null
@@ -287,20 +288,26 @@ class VpnService : android.net.VpnService(), KillSwitch, SocketProtector {
                         allowFamily(OsConstants.AF_INET6)
                     }
 
-                    // Only add DNS servers whose family is supported
-                    config.`interface`.dns?.let { rawDns ->
-                        val dnsConfig = rawDns.parseDns()
-                        dnsConfig.dnsServers.forEach { dnsServer ->
-                            val isIpv6 = dnsServer is Inet6Address
-                            if ((isIpv6 && hasIpv6) || (!isIpv6 && hasIpv4)) {
-                                addDnsServer(dnsServer)
-                            } else {
-                                Timber.w(
-                                    "Dropped DNS server $dnsServer: IP family not allowed by interface/routes"
-                                )
+                    if (extendedDnsEnabled) {
+                        val fakeDns = InetAddress.getByName(FAKE_DNS_IP)
+                        addDnsServer(fakeDns)
+                        addRoute(fakeDns, 32)
+                        Timber.d("Extended DNS enabled: using fake DNS $FAKE_DNS_IP")
+                    } else {
+                        config.`interface`.dns?.let { rawDns ->
+                            val dnsConfig = rawDns.parseDns()
+                            dnsConfig.dnsServers.forEach { dnsServer ->
+                                val isIpv6 = dnsServer is Inet6Address
+                                if ((isIpv6 && hasIpv6) || (!isIpv6 && hasIpv4)) {
+                                    addDnsServer(dnsServer)
+                                } else {
+                                    Timber.w(
+                                        "Dropped DNS server $dnsServer: IP family not allowed by interface/routes"
+                                    )
+                                }
                             }
+                            dnsConfig.searchDomains.forEach { addSearchDomain(it) }
                         }
-                        dnsConfig.searchDomains.forEach { addSearchDomain(it) }
                     }
                 }
                 .establish()
@@ -372,6 +379,8 @@ class VpnService : android.net.VpnService(), KillSwitch, SocketProtector {
         private const val IPV4_DEFAULT_ROUTE = "0.0.0.0"
         private const val IPV6_DEFAULT_ROUTE = "::"
         private const val DEFAULT_DNS_SERVER = "1.1.1.1"
+        private const val FAKE_DNS_IP = "10.111.222.53"
         const val HEV_BRIDGE_TRAFFIC_TAG = 0xF00D
+        val FAKE_DNS_IPS = setOf(FAKE_DNS_IP)
     }
 }

--- a/tunnel/tools/CMakeLists.txt
+++ b/tunnel/tools/CMakeLists.txt
@@ -24,8 +24,19 @@ target_include_directories(libam.so PUBLIC
 target_compile_options(libam.so PUBLIC -std=gnu11 -DRUNSTATEDIR=\"/data/data/${ANDROID_PACKAGE_NAME}/cache\")
 
 # Amnezia userspace go build
-add_custom_target(libam-go.so
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libwg-go"
+set(LIBWG_GO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libwg-go")
+file(GLOB_RECURSE LIBWG_GO_SRCS
+    "${LIBWG_GO_DIR}/*.go"
+    "${LIBWG_GO_DIR}/*.c"
+    "${LIBWG_GO_DIR}/*.h"
+)
+list(APPEND LIBWG_GO_SRCS
+    "${LIBWG_GO_DIR}/go.mod"
+    "${LIBWG_GO_DIR}/go.sum"
+)
+add_custom_command(
+    OUTPUT ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libam-go.so
+    WORKING_DIRECTORY "${LIBWG_GO_DIR}"
     COMMENT "Building amneziawg-go"
     VERBATIM
     COMMAND "${ANDROID_HOST_PREBUILTS}/bin/make"
@@ -39,11 +50,8 @@ add_custom_target(libam-go.so
         TARGET=${CMAKE_C_COMPILER_TARGET}
         DESTDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
         BUILDDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/../generated-src
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/main.go
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/vpn/vpn.go
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/vpn/vpn_jni.c
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/proxy/proxy.go
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/proxy/proxy_jni.c
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/dns/dns.go
-            ${CMAKE_CURRENT_SOURCE_DIR}/libwg-go/dns/dns_jni.c
+    DEPENDS ${LIBWG_GO_SRCS}
+)
+add_custom_target(libam-go.so ALL
+    DEPENDS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libam-go.so
 )

--- a/tunnel/tools/libwg-go/Makefile
+++ b/tunnel/tools/libwg-go/Makefile
@@ -33,6 +33,8 @@ GO_HASH_darwin-amd64 := 69bef555e114b4a2252452b6e7049afc31fbdf2d39790b669165e895
 GO_HASH_darwin-arm64 := 27973684b515eaf461065054e6b572d9390c05e69ba4a423076c160165336470
 GO_HASH_linux-amd64 := 77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
 
+GO_SRCS := $(shell find . -path './build' -prune -o -name '*.go' -print)
+
 default: $(DESTDIR)/libam-go.so
 
 $(GRADLE_USER_HOME)/caches/golang/$(GO_TARBALL):
@@ -52,7 +54,7 @@ $(BUILDDIR)/go-$(GO_VERSION)/.prepared: $(GRADLE_USER_HOME)/caches/golang/$(GO_T
 	touch "$@"'
 
 $(DESTDIR)/libam-go.so: export PATH := $(BUILDDIR)/go-$(GO_VERSION)/bin/:$(PATH)
-$(DESTDIR)/libam-go.so: $(BUILDDIR)/go-$(GO_VERSION)/.prepared go.mod
+$(DESTDIR)/libam-go.so: $(GO_SRCS) go.mod go.sum $(BUILDDIR)/go-$(GO_VERSION)/.prepared
 	go build -tags linux,notest,cgo -ldflags="-X github.com/amnezia-vpn/amneziawg-go/ipc.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/amneziawg -buildid=" -v -trimpath -buildvcs=false -o "$@" -buildmode c-shared
 
 .DELETE_ON_ERROR:

--- a/tunnel/tools/libwg-go/shared/logger.go
+++ b/tunnel/tools/libwg-go/shared/logger.go
@@ -2,29 +2,22 @@ package shared
 
 // #cgo LDFLAGS: -llog
 // #include <android/log.h>
+// #include <stdlib.h>
 import "C"
 import (
 	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"unsafe"
 
 	"github.com/amnezia-vpn/amneziawg-go/device"
 	"golang.org/x/sys/unix"
 )
 
-func cstring(s string) *C.char {
-	b, err := unix.BytePtrFromString(s)
-	if err != nil {
-		b := [1]C.char{}
-		return &b[0]
-	}
-	return (*C.char)(unsafe.Pointer(b))
-}
-
 func init() {
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, unix.SIGUSR2)
 	go func() {
 		buf := make([]byte, os.Getpagesize())
@@ -36,18 +29,34 @@ func init() {
 					n--
 				}
 				buf[n] = 0
-				C.__android_log_write(C.ANDROID_LOG_ERROR, cstring("AmneziaWG/Stacktrace"), (*C.char)(unsafe.Pointer(&buf[0])))
+				tag := C.CString("AmneziaWG/Stacktrace")
+				C.__android_log_write(C.ANDROID_LOG_ERROR, tag, (*C.char)(unsafe.Pointer(&buf[0])))
+				C.free(unsafe.Pointer(tag))
 			}
 		}
 	}()
 }
 
+func sanitize(s string) string {
+	return strings.ReplaceAll(s, "\x00", "\\0")
+}
+
 func LogDebug(tag string, format string, args ...interface{}) {
-	C.__android_log_write(C.ANDROID_LOG_DEBUG, cstring(tag), cstring(fmt.Sprintf(format, args...)))
+	msg := sanitize(fmt.Sprintf(format, args...))
+	cTag := C.CString(tag)
+	cMsg := C.CString(msg)
+	C.__android_log_write(C.ANDROID_LOG_DEBUG, cTag, cMsg)
+	C.free(unsafe.Pointer(cTag))
+	C.free(unsafe.Pointer(cMsg))
 }
 
 func LogError(tag string, format string, args ...interface{}) {
-	C.__android_log_write(C.ANDROID_LOG_ERROR, cstring(tag), cstring(fmt.Sprintf(format, args...)))
+	msg := sanitize(fmt.Sprintf(format, args...))
+	cTag := C.CString(tag)
+	cMsg := C.CString(msg)
+	C.__android_log_write(C.ANDROID_LOG_ERROR, cTag, cMsg)
+	C.free(unsafe.Pointer(cTag))
+	C.free(unsafe.Pointer(cMsg))
 }
 
 func NewLogger(tag string) *device.Logger {

--- a/tunnel/tools/libwg-go/vpn/extendeddns.go
+++ b/tunnel/tools/libwg-go/vpn/extendeddns.go
@@ -1,0 +1,570 @@
+package vpn
+
+/*
+#include "vpn_jni.h"
+*/
+import "C"
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/amnezia-vpn/amneziawg-go/tun"
+	"github.com/miekg/dns"
+	"github.com/wgtunnel/android/shared"
+	"golang.org/x/sys/unix"
+)
+
+const fakeDnsIP = "10.111.222.53"
+const maxPendingDnsQueries = 64
+const maxCacheEntries = 512
+const cacheCleanupInterval = 60 * time.Second
+
+type ExtendedDnsRule struct {
+	Domains []string
+	Servers []string
+}
+
+type ExtendedDnsConfig struct {
+	Rules            []ExtendedDnsRule
+	SystemDnsServers []string
+}
+
+type dnsCacheEntry struct {
+	reply  *dns.Msg
+	expiry time.Time
+}
+
+type extendedDnsWrapper struct {
+	realTun            tun.Device
+	fakeIP             netip.Addr
+	config             *ExtendedDnsConfig
+	configMu           sync.RWMutex
+	tunnelClient       dns.Client
+	bypassClient       *dns.Client
+	ctx                context.Context
+	cancel             context.CancelFunc
+	cache              map[string]dnsCacheEntry
+	cacheMu            sync.Mutex
+	cacheCleanupTicker *time.Ticker
+}
+
+var dnsQuerySem = make(chan struct{}, maxPendingDnsQueries)
+
+var (
+	dnsWrappers = make(map[int32]*extendedDnsWrapper)
+	dnsMu       sync.RWMutex
+)
+
+func registerDnsWrapper(handle int32, w *extendedDnsWrapper) {
+	dnsMu.Lock()
+	dnsWrappers[handle] = w
+	dnsMu.Unlock()
+}
+
+func unregisterDnsWrapper(handle int32) {
+	dnsMu.Lock()
+	delete(dnsWrappers, handle)
+	dnsMu.Unlock()
+}
+
+var bypassDialer = &net.Dialer{
+	Control: func(network, address string, c syscall.RawConn) error {
+		var opErr error
+		c.Control(func(fd uintptr) {
+			if C.bypass_socket(C.int(fd)) == 0 {
+				opErr = unix.EACCES
+			}
+		})
+		return opErr
+	},
+}
+
+func extractDnsFromConfig(config string) string {
+	for _, line := range strings.Split(config, "\n") {
+		trimmed := strings.TrimSpace(line)
+		lower := strings.ToLower(trimmed)
+		if !strings.HasPrefix(lower, "dns") {
+			continue
+		}
+		if len(lower) > 3 {
+			c := lower[3]
+			if c != '=' && c != ' ' && c != '\t' {
+				continue
+			}
+		}
+		eqIdx := strings.IndexByte(trimmed, '=')
+		if eqIdx >= 0 {
+			return strings.TrimSpace(trimmed[eqIdx+1:])
+		}
+	}
+	return ""
+}
+
+func newExtendedDnsWrapper(realTun tun.Device, rawConfig string, rawSystemDnsServers string) *extendedDnsWrapper {
+	fakeIP := netip.MustParseAddr(fakeDnsIP)
+	rules := parseExtendedDnsRules(rawConfig)
+	rawSystemDnsServers = strings.Map(func(rune rune) rune {
+		if rune == 0 || rune == 32 {
+			return -1
+		}
+		return rune
+	}, rawSystemDnsServers)
+
+	config := &ExtendedDnsConfig{
+		Rules:            rules,
+		SystemDnsServers: strings.Split(rawSystemDnsServers, ","),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w := &extendedDnsWrapper{
+		realTun: realTun,
+		fakeIP:  fakeIP,
+		config:  config,
+		tunnelClient: dns.Client{
+			Timeout: 5 * time.Second,
+		},
+		bypassClient: &dns.Client{
+			Timeout: 5 * time.Second,
+			Dialer:  bypassDialer,
+		},
+		ctx:    ctx,
+		cancel: cancel,
+		cache:  make(map[string]dnsCacheEntry),
+	}
+
+	w.cacheCleanupTicker = time.NewTicker(cacheCleanupInterval)
+	go func() {
+		for {
+			select {
+			case <-w.cacheCleanupTicker.C:
+				w.evictExpired()
+			case <-w.ctx.Done():
+				w.cacheCleanupTicker.Stop()
+				return
+			}
+		}
+	}()
+
+	return w
+}
+
+func parseExtendedDnsRules(raw string) []ExtendedDnsRule {
+	extendedDnsRules := []ExtendedDnsRule{}
+	raw = strings.TrimRight(raw, ",")
+	raw = strings.ReplaceAll(raw, " ", "")
+	parts := strings.Split(raw, ",")
+	var servers []string
+	var domains []string
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if ip := net.ParseIP(p); ip != nil {
+			if len(domains) > 0 {
+				extendedDnsRules = append(extendedDnsRules, ExtendedDnsRule{Servers: servers, Domains: domains})
+				shared.LogDebug(tag, "DNS rule added: domains=%v servers=%v", domains, servers)
+				servers = []string{}
+				domains = []string{}
+			}
+			servers = append(servers, p)
+		} else {
+			if len(servers) == 0 {
+				continue
+			}
+			domains = append(domains, strings.ToLower(p))
+		}
+	}
+	if len(servers) > 0 {
+		if len(domains) == 0 {
+			domains = append(domains, "~")
+		}
+		extendedDnsRules = append(extendedDnsRules, ExtendedDnsRule{Servers: servers, Domains: domains})
+		shared.LogDebug(tag, "DNS rule added: domains=%v servers=%v", domains, servers)
+	}
+	return extendedDnsRules
+}
+
+func (w *extendedDnsWrapper) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	n, err := w.realTun.Read(bufs, sizes, offset)
+	if err != nil {
+		return n, err
+	}
+
+	for i := 0; i < n; i++ {
+		pkt := bufs[i][offset : offset+sizes[i]]
+		if len(pkt) < 20 {
+			continue
+		}
+		if !w.isDnsQuery(pkt) {
+			continue
+		}
+		sizes[i] = 0
+		pktCopy := make([]byte, len(pkt))
+		copy(pktCopy, pkt)
+		select {
+		case dnsQuerySem <- struct{}{}:
+			go func() {
+				defer func() { <-dnsQuerySem }()
+				w.handleDnsQuery(pktCopy)
+			}()
+		default:
+			shared.LogDebug(tag, "dropped DNS query for %s (too many pending)", "<unknown>")
+		}
+	}
+
+	return n, nil
+}
+
+func (w *extendedDnsWrapper) isDnsQuery(pkt []byte) bool {
+	if len(pkt) < 20 {
+		return false
+	}
+	version := pkt[0] >> 4
+	switch version {
+	case 4:
+		ihl := int(pkt[0]&0x0f) * 4
+		if ihl < 20 || ihl > len(pkt) {
+			return false
+		}
+		if pkt[9] != 17 {
+			return false
+		}
+		totalLen := int(binary.BigEndian.Uint16(pkt[2:4]))
+		if totalLen > len(pkt) {
+			totalLen = len(pkt)
+		}
+		if ihl+8 > totalLen {
+			return false
+		}
+		dstIP, ok := netip.AddrFromSlice(pkt[16:20])
+		if !ok || dstIP != w.fakeIP {
+			return false
+		}
+		dstPort := int(binary.BigEndian.Uint16(pkt[ihl+2 : ihl+4]))
+		return dstPort == 53
+	}
+	return false
+}
+
+func (w *extendedDnsWrapper) handleDnsQuery(pkt []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			shared.LogError(tag, "panic in handleDnsQuery: %v", r)
+		}
+	}()
+
+	version := pkt[0] >> 4
+	var hdrLen int
+	var srcIP, dstIP []byte
+	var totalLen int
+
+	switch version {
+	case 4:
+		hdrLen = int(pkt[0]&0x0f) * 4
+		totalLen = int(binary.BigEndian.Uint16(pkt[2:4]))
+		srcIP = pkt[12:16]
+		dstIP = pkt[16:20]
+	default:
+		return
+	}
+
+	if totalLen > len(pkt) {
+		totalLen = len(pkt)
+	}
+
+	srcPort := int(binary.BigEndian.Uint16(pkt[hdrLen : hdrLen+2]))
+	dstPort := int(binary.BigEndian.Uint16(pkt[hdrLen+2 : hdrLen+4]))
+	udpLen := int(binary.BigEndian.Uint16(pkt[hdrLen+4 : hdrLen+6]))
+
+	dnsStart := hdrLen + 8
+	dnsLen := udpLen - 8
+	if dnsLen <= 0 || dnsStart+dnsLen > totalLen {
+		return
+	}
+
+	msg := new(dns.Msg)
+	if err := msg.Unpack(pkt[dnsStart : dnsStart+dnsLen]); err != nil {
+		return
+	}
+	if len(msg.Question) == 0 {
+		return
+	}
+
+	qname := msg.Question[0].Name
+	if strings.HasSuffix(qname, ".") {
+		qname = qname[:len(qname)-1]
+	}
+
+	rule, matched := w.matchDomain(qname)
+	var servers []string
+	if matched {
+		servers = rule.Servers
+		shared.LogDebug(tag, "matched %s: %d server(s) from rule", qname, len(servers))
+	} else {
+		w.configMu.RLock()
+		servers = cloneStrings(w.config.SystemDnsServers)
+		w.configMu.RUnlock()
+		shared.LogDebug(tag, "non matched %s: %d server(s) from system dns", qname, len(servers))
+	}
+	if len(servers) == 0 {
+		shared.LogDebug(tag, "no upstream for %s, returning NXDOMAIN (no DNS servers configured)", qname)
+		resp := w.buildReply(msg, dns.RcodeNameError)
+		w.writeResponse(version, srcIP, dstIP, srcPort, dstPort, resp)
+		return
+	}
+
+	if cached := w.cacheGet(qname); cached != nil {
+		cached.Id = msg.Id
+		w.writeResponse(version, srcIP, dstIP, srcPort, dstPort, cached)
+		return
+	}
+
+	proxy := new(dns.Msg)
+	proxy.SetQuestion(msg.Question[0].Name, msg.Question[0].Qtype)
+	proxy.SetEdns0(4096, true)
+
+	client := w.bypassClient
+	if matched {
+		client = &w.tunnelClient
+	}
+
+	for _, timeout := range []time.Duration{500 * time.Millisecond, 5 * time.Second} {
+		for _, server := range servers {
+			upAddr, _, err := net.SplitHostPort(server)
+			if err != nil {
+				upAddr = server
+				server = net.JoinHostPort(server, "53")
+			}
+
+			ctx, cancel := context.WithTimeout(w.ctx, timeout)
+			reply, _, err := client.ExchangeContext(ctx, proxy, server)
+			cancel()
+			if err != nil || reply == nil {
+				shared.LogError(tag, "resolve %s via %s FAILED (timeout=%v): %v", qname, upAddr, timeout, err)
+				continue
+			}
+			shared.LogDebug(tag, "resolve %s via %s OK (timeout=%v)", qname, upAddr, timeout)
+
+			w.cacheSet(qname, reply)
+			reply.Id = msg.Id
+			w.writeResponse(version, srcIP, dstIP, srcPort, dstPort, reply)
+			return
+		}
+	}
+
+	shared.LogError(tag, "all upstreams failed for %s (matched=%v), returning SERVFAIL", qname, matched)
+	resp := w.buildReply(msg, dns.RcodeServerFailure)
+	w.writeResponse(version, srcIP, dstIP, srcPort, dstPort, resp)
+}
+
+func cloneStrings(src []string) []string {
+	dst := make([]string, len(src))
+	for i, s := range src {
+		dst[i] = strings.Clone(s)
+	}
+	return dst
+}
+
+func (w *extendedDnsWrapper) setSystemDnsServers(systemDnsServers []string) {
+	w.configMu.Lock()
+	defer w.configMu.Unlock()
+	w.config.SystemDnsServers = cloneStrings(systemDnsServers)
+}
+
+func (w *extendedDnsWrapper) matchDomain(qname string) (*ExtendedDnsRule, bool) {
+	w.configMu.RLock()
+	defer w.configMu.RUnlock()
+	rules := w.config.Rules
+	qnameLower := strings.ToLower(qname)
+	for i := range rules {
+		for _, domainPattern := range rules[i].Domains {
+			var matched bool
+			if strings.HasPrefix(domainPattern, "~") {
+				suffix := strings.TrimPrefix(domainPattern, "~")
+				matched = suffix == "" || strings.HasSuffix(qnameLower, suffix) || qnameLower == suffix
+			} else {
+				matched = qnameLower == domainPattern
+			}
+			if matched {
+				return &rules[i], true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (w *extendedDnsWrapper) buildReply(query *dns.Msg, rcode int) *dns.Msg {
+	reply := &dns.Msg{}
+	reply.SetReply(query)
+	reply.Rcode = rcode
+	return reply
+}
+
+func (w *extendedDnsWrapper) cacheGet(qname string) *dns.Msg {
+	w.cacheMu.Lock()
+	defer w.cacheMu.Unlock()
+	entry, ok := w.cache[qname]
+	if !ok || time.Now().After(entry.expiry) {
+		if ok {
+			delete(w.cache, qname)
+		}
+		return nil
+	}
+	data, _ := entry.reply.Pack()
+	if data == nil {
+		return nil
+	}
+	reply := new(dns.Msg)
+	reply.Unpack(data)
+	return reply
+}
+
+func (w *extendedDnsWrapper) cacheSet(qname string, reply *dns.Msg) {
+	if reply.Rcode != dns.RcodeSuccess {
+		return
+	}
+	minTTL := uint32(60)
+	for _, rr := range reply.Answer {
+		if t := rr.Header().Ttl; t < minTTL {
+			minTTL = t
+		}
+	}
+	data, _ := reply.Pack()
+	if data == nil {
+		return
+	}
+	cached := new(dns.Msg)
+	cached.Unpack(data)
+	expiry := time.Now().Add(time.Duration(minTTL) * time.Second)
+
+	w.cacheMu.Lock()
+	defer w.cacheMu.Unlock()
+
+	if _, exists := w.cache[qname]; !exists && len(w.cache) >= maxCacheEntries {
+		evictCount := maxCacheEntries / 5
+		for key := range w.cache {
+			if evictCount <= 0 {
+				break
+			}
+			delete(w.cache, key)
+			evictCount--
+		}
+	}
+
+	w.cache[qname] = dnsCacheEntry{reply: cached, expiry: expiry}
+}
+
+func (w *extendedDnsWrapper) evictExpired() {
+	w.cacheMu.Lock()
+	defer w.cacheMu.Unlock()
+	now := time.Now()
+	for key, entry := range w.cache {
+		if now.After(entry.expiry) {
+			delete(w.cache, key)
+		}
+	}
+}
+
+func computeChecksum(data []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(data); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(data[i : i+2]))
+	}
+	if len(data)%2 == 1 {
+		sum += uint32(data[len(data)-1]) << 8
+	}
+	for sum > 0xffff {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return uint16(^sum)
+}
+
+func (w *extendedDnsWrapper) writeResponse(version byte, srcIP, dstIP []byte, srcPort, dstPort int, dnsMsg *dns.Msg) {
+	dnsResp, err := dnsMsg.Pack()
+	if err != nil || dnsResp == nil {
+		return
+	}
+
+	udpLen := 8 + len(dnsResp)
+
+	switch version {
+	case 4:
+		ipTotalLen := 20 + udpLen
+		buf := make([]byte, ipTotalLen)
+
+		buf[0] = 0x45
+		buf[1] = 0
+		binary.BigEndian.PutUint16(buf[2:4], uint16(ipTotalLen))
+		binary.BigEndian.PutUint16(buf[4:6], 0)
+		binary.BigEndian.PutUint16(buf[6:8], 0)
+		buf[8] = 64
+		buf[9] = 17
+		binary.BigEndian.PutUint16(buf[10:12], 0)
+		copy(buf[12:16], dstIP)
+		copy(buf[16:20], srcIP)
+
+		var sum uint32
+		for i := 0; i < 20; i += 2 {
+			sum += uint32(binary.BigEndian.Uint16(buf[i : i+2]))
+		}
+		for sum > 0xffff {
+			sum = (sum & 0xffff) + (sum >> 16)
+		}
+		binary.BigEndian.PutUint16(buf[10:12], uint16(^sum))
+
+		binary.BigEndian.PutUint16(buf[20:22], uint16(dstPort))
+		binary.BigEndian.PutUint16(buf[22:24], uint16(srcPort))
+		binary.BigEndian.PutUint16(buf[24:26], uint16(udpLen))
+		binary.BigEndian.PutUint16(buf[26:28], 0)
+		copy(buf[28:], dnsResp)
+
+		pseudo := make([]byte, 0, 12+udpLen)
+		pseudo = append(pseudo, dstIP[:4]...)
+		pseudo = append(pseudo, srcIP[:4]...)
+		pseudo = append(pseudo, 0, 17)
+		pseudo = binary.BigEndian.AppendUint16(pseudo, uint16(udpLen))
+		pseudo = append(pseudo, buf[20:20+udpLen]...)
+		binary.BigEndian.PutUint16(buf[26:28], computeChecksum(pseudo))
+
+		if _, err := w.realTun.Write([][]byte{buf}, 0); err != nil {
+			shared.LogError(tag, "write response: %v", err)
+		}
+	}
+}
+
+func (w *extendedDnsWrapper) Write(bufs [][]byte, offset int) (int, error) {
+	return w.realTun.Write(bufs, offset)
+}
+
+func (w *extendedDnsWrapper) File() *os.File {
+	return w.realTun.File()
+}
+
+func (w *extendedDnsWrapper) MTU() (int, error) {
+	return w.realTun.MTU()
+}
+
+func (w *extendedDnsWrapper) Name() (string, error) {
+	return w.realTun.Name()
+}
+
+func (w *extendedDnsWrapper) Events() <-chan tun.Event {
+	return w.realTun.Events()
+}
+
+func (w *extendedDnsWrapper) Close() error {
+	w.cancel()
+	return w.realTun.Close()
+}
+
+func (w *extendedDnsWrapper) BatchSize() int {
+	return w.realTun.BatchSize()
+}

--- a/tunnel/tools/libwg-go/vpn/vpn.go
+++ b/tunnel/tools/libwg-go/vpn/vpn.go
@@ -41,12 +41,22 @@ func init() {
 }
 
 //export awgTurnOn
-func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath string) int32 {
+func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath string, systemDnsServers string) int32 {
+	settings = strings.Clone(settings)
+	systemDnsServers = strings.Clone(systemDnsServers)
 	tunnel, name, err := tun.CreateUnmonitoredTUNFromFD(int(tunFd))
 	if err != nil {
 		unix.Close(int(tunFd))
 		shared.LogError(tag, "CreateUnmonitoredTUNFromFD: %v", err)
 		return -1
+	}
+
+	var dnsWrapper *extendedDnsWrapper
+	extendedDnsConfig := extractDnsFromConfig(settings)
+	if extendedDnsConfig != "" {
+		shared.LogDebug(tag, "Extended DNS enabled, wrapping TUN device")
+		dnsWrapper = newExtendedDnsWrapper(tunnel, extendedDnsConfig, systemDnsServers)
+		tunnel = dnsWrapper
 	}
 
 	conf, err := wireproxyawg.ParseConfigString(settings)
@@ -144,6 +154,11 @@ func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath stri
 		uapi:   uapi,
 	}
 	tunnelMu.Unlock()
+
+	if dnsWrapper != nil {
+		registerDnsWrapper(handle, dnsWrapper)
+	}
+
 	return handle
 }
 
@@ -196,6 +211,8 @@ func awgTurnOff(tunnelHandle int32) {
 
 	tunnelMu.Unlock()
 
+	unregisterDnsWrapper(tunnelHandle)
+
 	if handle.uapi != nil {
 		handle.uapi.Close()
 	}
@@ -245,6 +262,24 @@ func awgTriggerBindUpdate(handle int32) {
 		shared.LogDebug(tag, "Calling BindUpdate on VPN handle %d", handle)
 		h.device.BindUpdate()
 	}
+}
+
+//export awgUpdateSystemDns
+func awgUpdateSystemDns(tunnelHandle int32, systemDnsServers string) int32 {
+	dnsMu.RLock()
+	wrapper, ok := dnsWrappers[tunnelHandle]
+	dnsMu.RUnlock()
+	if !ok {
+		shared.LogDebug(tag, "Extended DNS not enabled for handle %d", tunnelHandle)
+		return -1
+	}
+
+	systemDnsServers = strings.Clone(systemDnsServers)
+	servers := strings.Split(systemDnsServers, ",")
+
+	wrapper.setSystemDnsServers(servers)
+	shared.LogDebug(tag, "Updated system DNS servers of %d: server(s)=%v", tunnelHandle, servers)
+	return 0
 }
 
 //export awgVersion

--- a/tunnel/tools/libwg-go/vpn/vpn_jni.c
+++ b/tunnel/tools/libwg-go/vpn/vpn_jni.c
@@ -9,35 +9,37 @@
 #include <vpn_jni.h>
 
 struct go_string { const char *str; long n; };
-extern int awgTurnOn(struct go_string ifname, int tun_fd, struct go_string settings, struct go_string uapipath);
+extern int awgTurnOn(struct go_string ifname, int tun_fd, struct go_string settings, struct go_string uapipath, struct go_string systemDnsServers);
 extern void awgTurnOff(int handle);
 extern char *awgGetConfig(int handle);
 extern char *awgVersion();
 extern void awgTriggerBindUpdate(int handle);
 extern int awgUpdateTunnelPeers(int handle, struct go_string settings);
+extern int awgUpdateSystemDns(int handle, struct go_string systemDnsServers);
 
-JNIEXPORT jint JNICALL  Java_com_zaneschepke_tunnel_VpnBackend_awgTurnOn(JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings, jstring uapipath)
+JNIEXPORT jint JNICALL  Java_com_zaneschepke_tunnel_VpnBackend_awgTurnOn(JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings, jstring uapipath, jstring systemDnsServers)
 {
-const char *ifname_str = (*env)->GetStringUTFChars(env, ifname, 0);
-size_t ifname_len = (*env)->GetStringUTFLength(env, ifname);
-const char *settings_str = (*env)->GetStringUTFChars(env, settings, 0);
-size_t settings_len = (*env)->GetStringUTFLength(env, settings);
-const char *uapipath_str = (*env)->GetStringUTFChars(env, uapipath, 0);
-size_t uapipath_len = (*env)->GetStringUTFLength(env, uapipath);
-int ret = awgTurnOn((struct go_string){
-.str = ifname_str,
-.n = ifname_len
-}, tun_fd, (struct go_string){
-.str = settings_str,
-.n = settings_len
-}, (struct go_string){
-.str = uapipath_str,
-.n = uapipath_len
-});
-(*env)->ReleaseStringUTFChars(env, ifname, ifname_str);
-(*env)->ReleaseStringUTFChars(env, settings, settings_str);
-(*env)->ReleaseStringUTFChars(env, uapipath, uapipath_str);
-return ret;
+    const char *ifname_str = (*env)->GetStringUTFChars(env, ifname, 0);
+    size_t ifname_len = (*env)->GetStringUTFLength(env, ifname);
+    const char *settings_str = (*env)->GetStringUTFChars(env, settings, 0);
+    size_t settings_len = (*env)->GetStringUTFLength(env, settings);
+    const char *uapipath_str = (*env)->GetStringUTFChars(env, uapipath, 0);
+    size_t uapipath_len = (*env)->GetStringUTFLength(env, uapipath);
+    const char *system_dns_str = NULL;
+    size_t system_dns_len = 0;
+    system_dns_str = (*env)->GetStringUTFChars(env, systemDnsServers, 0);
+    system_dns_len = (*env)->GetStringUTFLength(env, systemDnsServers);
+    int ret = awgTurnOn(
+        (struct go_string){ .str = ifname_str, .n = ifname_len },
+        tun_fd,
+        (struct go_string){ .str = settings_str, .n = settings_len },
+        (struct go_string){ .str = uapipath_str, .n = uapipath_len },
+        (struct go_string){ .str = system_dns_str, .n = system_dns_len });
+    (*env)->ReleaseStringUTFChars(env, ifname, ifname_str);
+    (*env)->ReleaseStringUTFChars(env, settings, settings_str);
+    (*env)->ReleaseStringUTFChars(env, uapipath, uapipath_str);
+    (*env)->ReleaseStringUTFChars(env, systemDnsServers, system_dns_str);
+    return ret;
 }
 
 JNIEXPORT void JNICALL  Java_com_zaneschepke_tunnel_VpnBackend_awgTurnOff(JNIEnv *env, jclass c, jint handle)
@@ -82,4 +84,16 @@ return ret;
 JNIEXPORT void JNICALL Java_com_zaneschepke_tunnel_VpnBackend_awgTriggerBindUpdate
 (JNIEnv *env, jclass clazz, jint handle) {
     awgTriggerBindUpdate(handle);
+}
+
+JNIEXPORT jint JNICALL Java_com_zaneschepke_tunnel_VpnBackend_awgUpdateSystemDns(JNIEnv *env, jclass clazz, jint handle, jstring systemDnsServers)
+{
+    const char *dns_str = (*env)->GetStringUTFChars(env, systemDnsServers, 0);
+    size_t dns_len = (*env)->GetStringUTFLength(env, systemDnsServers);
+    int ret = awgUpdateSystemDns(handle, (struct go_string){
+        .str = dns_str,
+        .n = dns_len
+    });
+    (*env)->ReleaseStringUTFChars(env, systemDnsServers, dns_str);
+    return ret;
 }


### PR DESCRIPTION
Introduction to **Extended DNS Resolver** feature, allowing per-domain DNS routing rules. 

## Added Features
- **Extended DNS Resolver** (Go-based TUN wrapper): Intercepts DNS queries via a fake IP (`10.111.222.53`), matches query domains against subdomain rules defined in the tunnel config's `DNS =` line, and routes matched queries through the tunnel while sending unmatched queries directly to the system DNS (bypassing the tunnel)
- **Global settings toggle** to enable/disable the extended DNS resolver
- **DNS config rule syntax**: `DNS = 10.0.0.53, ~internal.corp, 1.1.1.1` — entries prefixed with `~` are treated as subdomain match suffixes associated with the preceding DNS server(s)
- **DNS response caching** with TTL-based expiry and LRU eviction (max 512 entries)
- **Automatic fallback DNS updates** when the active network changes (system DNS tracked per-network)
- **Warning snackbars** when configs containing `~` DNS rules are imported/saved/copied but the Extended DNS toggle is off

## Caveats
- Private DNS (Android DNS-over-TLS) may prevent the Extended DNS resolver from intercepting queries — a warning string is provided but enforcement is not automatic
- The `~` prefix is a custom extension, not standard WireGuard syntax — configs with `~` rules will not work with other WireGuard clients
- The fake DNS IP (`10.111.222.53`) must not conflict with the tunnel's allowed IPs/routes
- A maximum of 64 concurrent DNS queries is enforced; excess queries are dropped
- Only DNS queries directed to the fake IP are intercepted — if an app uses a hardcoded DNS server, it will bypass the resolver
- IPv6 fake DNS is not yet supported (planned as a follow-up)
- Since I have tested this feature running just one tunnel over vpn mode, I consider the lack of qualified testing a big caveat.
