### PR TITLE
feat: per-tunnel split DNS

### DIFF
--- a/app/schemas/com.zaneschepke.wireguardautotunnel.data.AppDatabase/35.json
+++ b/app/schemas/com.zaneschepke.wireguardautotunnel.data.AppDatabase/35.json
@@ -1,0 +1,527 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 35,
+    "identityHash": "93350c31b3136daeac7a9562da75a689",
+    "entities": [
+      {
+        "tableName": "tunnel_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `tunnel_networks` TEXT NOT NULL DEFAULT '[]', `is_mobile_data_tunnel` INTEGER NOT NULL DEFAULT false, `is_primary_tunnel` INTEGER NOT NULL DEFAULT false, `quick_config` TEXT NOT NULL DEFAULT '', `is_ethernet_tunnel` INTEGER NOT NULL DEFAULT false, `prefer_ipv6` INTEGER NOT NULL DEFAULT false, `position` INTEGER NOT NULL DEFAULT 0, `auto_tunnel_apps` TEXT NOT NULL DEFAULT '[]', `is_metered` INTEGER NOT NULL DEFAULT false, `ipv6_restore` INTEGER NOT NULL DEFAULT false, `tunnel_bssids` TEXT NOT NULL DEFAULT '[]', `split_dns_domains` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tunnelNetworks",
+            "columnName": "tunnel_networks",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isMobileDataTunnel",
+            "columnName": "is_mobile_data_tunnel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isPrimaryTunnel",
+            "columnName": "is_primary_tunnel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "quickConfig",
+            "columnName": "quick_config",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isEthernetTunnel",
+            "columnName": "is_ethernet_tunnel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isIpv6Preferred",
+            "columnName": "prefer_ipv6",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoTunnelApps",
+            "columnName": "auto_tunnel_apps",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isMetered",
+            "columnName": "is_metered",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "ipv6RestoreEnabled",
+            "columnName": "ipv6_restore",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "tunnelBSSIDs",
+            "columnName": "tunnel_bssids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "splitDnsDomains",
+            "columnName": "split_dns_domains",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tunnel_config_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tunnel_config_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "proxy_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `socks5_proxy_enabled` INTEGER NOT NULL DEFAULT 0, `socks5_proxy_bind_address` TEXT, `http_proxy_enable` INTEGER NOT NULL DEFAULT 0, `http_proxy_bind_address` TEXT, `proxy_username` TEXT, `proxy_password` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "socks5ProxyEnabled",
+            "columnName": "socks5_proxy_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "socks5ProxyBindAddress",
+            "columnName": "socks5_proxy_bind_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "httpProxyEnabled",
+            "columnName": "http_proxy_enable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "httpProxyBindAddress",
+            "columnName": "http_proxy_bind_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proxyUsername",
+            "columnName": "proxy_username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proxyPassword",
+            "columnName": "proxy_password",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "general_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_shortcuts_enabled` INTEGER NOT NULL DEFAULT 0, `is_restore_on_boot_enabled` INTEGER NOT NULL DEFAULT 0, `is_multi_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `global_split_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `app_mode` INTEGER NOT NULL DEFAULT 0, `theme` TEXT NOT NULL DEFAULT 'AUTOMATIC', `locale` TEXT, `remote_key` TEXT, `is_remote_control_enabled` INTEGER NOT NULL DEFAULT 0, `is_pin_lock_enabled` INTEGER NOT NULL DEFAULT 0, `is_always_on_vpn_enabled` INTEGER NOT NULL DEFAULT 0, `already_donated` INTEGER NOT NULL DEFAULT 0, `screen_recording_security` INTEGER NOT NULL DEFAULT 1, `global_amnezia_enabled` INTEGER NOT NULL DEFAULT 0, `tunnel_scripting_enabled` INTEGER NOT NULL DEFAULT 0, `seamless_recovery` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShortcutsEnabled",
+            "columnName": "is_shortcuts_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isRestoreOnBootEnabled",
+            "columnName": "is_restore_on_boot_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isMultiTunnelEnabled",
+            "columnName": "is_multi_tunnel_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isGlobalSplitTunnelEnabled",
+            "columnName": "global_split_tunnel_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "tunnelMode",
+            "columnName": "app_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'AUTOMATIC'"
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteKey",
+            "columnName": "remote_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRemoteControlEnabled",
+            "columnName": "is_remote_control_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isPinLockEnabled",
+            "columnName": "is_pin_lock_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isAlwaysOnVpnEnabled",
+            "columnName": "is_always_on_vpn_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "alreadyDonated",
+            "columnName": "already_donated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "screenRecordingSecurityEnabled",
+            "columnName": "screen_recording_security",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "isGlobalAmneziaEnabled",
+            "columnName": "global_amnezia_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "tunnelScriptingEnabled",
+            "columnName": "tunnel_scripting_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "seamlessRecoveryEnabled",
+            "columnName": "seamless_recovery",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "auto_tunnel_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_tunnel_enabled` INTEGER NOT NULL DEFAULT 0, `is_tunnel_on_mobile_data_enabled` INTEGER NOT NULL DEFAULT 0, `trusted_network_ssids` TEXT NOT NULL DEFAULT '[]', `is_tunnel_on_ethernet_enabled` INTEGER NOT NULL DEFAULT 0, `is_tunnel_on_wifi_enabled` INTEGER NOT NULL DEFAULT 0, `is_wildcards_enabled` INTEGER NOT NULL DEFAULT 0, `is_stop_on_no_internet_enabled` INTEGER NOT NULL DEFAULT 0, `is_tunnel_on_unsecure_enabled` INTEGER NOT NULL DEFAULT 0, `wifi_detection_method` INTEGER NOT NULL DEFAULT 0, `start_on_boot` INTEGER NOT NULL DEFAULT 0, `disable_on_captive_portal` INTEGER NOT NULL DEFAULT 1, `trusted_network_bssids` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutoTunnelEnabled",
+            "columnName": "is_tunnel_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTunnelOnMobileDataEnabled",
+            "columnName": "is_tunnel_on_mobile_data_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "trustedNetworkSSIDs",
+            "columnName": "trusted_network_ssids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isTunnelOnEthernetEnabled",
+            "columnName": "is_tunnel_on_ethernet_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTunnelOnWifiEnabled",
+            "columnName": "is_tunnel_on_wifi_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isWildcardsEnabled",
+            "columnName": "is_wildcards_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isStopOnNoInternetEnabled",
+            "columnName": "is_stop_on_no_internet_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTunnelOnUnsecureEnabled",
+            "columnName": "is_tunnel_on_unsecure_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "wifiDetectionMethod",
+            "columnName": "wifi_detection_method",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "startOnBoot",
+            "columnName": "start_on_boot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "disableTunnelOnCaptivePortal",
+            "columnName": "disable_on_captive_portal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "trustedNetworkBSSIDs",
+            "columnName": "trusted_network_bssids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "monitoring_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_local_logs_enabled` INTEGER NOT NULL DEFAULT 0, `tunnel_statistics_enabled` INTEGER NOT NULL DEFAULT 1, `tunnel_statistics_poll_interval` INTEGER NOT NULL DEFAULT 3)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocalLogsEnabled",
+            "columnName": "is_local_logs_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "tunnelStatisticsEnabled",
+            "columnName": "tunnel_statistics_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "tunnelStatisticsPollInterval",
+            "columnName": "tunnel_statistics_poll_interval",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "3"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dns_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `dns_protocol` INTEGER NOT NULL DEFAULT 0, `dns_endpoint` TEXT, `global_tunnel_dns_enabled` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dnsProtocol",
+            "columnName": "dns_protocol",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dnsEndpoint",
+            "columnName": "dns_endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isGlobalTunnelDnsEnabled",
+            "columnName": "global_tunnel_dns_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lockdown_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bypass_lan` INTEGER NOT NULL DEFAULT 0, `metered` INTEGER NOT NULL DEFAULT 0, `dual_stack` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bypassLan",
+            "columnName": "bypass_lan",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "metered",
+            "columnName": "metered",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dualStack",
+            "columnName": "dual_stack",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93350c31b3136daeac7a9562da75a689')"
+    ]
+  }
+}

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
@@ -125,6 +125,7 @@ import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.settings.config.Co
 import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.settings.config.edit.ConfigEditScreen
 import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.settings.ipv6.IPv6Screen
 import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.sort.SortScreen
+import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.splitdns.SplitDnsScreen
 import com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.splittunnel.SplitTunnelScreen
 import com.zaneschepke.wireguardautotunnel.ui.theme.AlertRed
 import com.zaneschepke.wireguardautotunnel.ui.theme.Heart
@@ -142,6 +143,7 @@ import com.zaneschepke.wireguardautotunnel.util.extensions.restartApp
 import com.zaneschepke.wireguardautotunnel.util.permission.LocalNetworkPermissionHelper
 import com.zaneschepke.wireguardautotunnel.viewmodel.ConfigEditViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SharedAppViewModel
+import com.zaneschepke.wireguardautotunnel.viewmodel.SplitDnsViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SplitTunnelViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.TunnelViewModel
 import de.raphaelebner.roomdatabasebackup.core.OnCompleteListener.Companion.EXIT_CODE_ERROR
@@ -558,6 +560,13 @@ class MainActivity : AppCompatActivity() {
                                                             parameters = { parametersOf(key.id) }
                                                         )
                                                     SplitTunnelScreen(viewModel)
+                                                }
+                                                entry<Route.SplitDns> { key ->
+                                                    val viewModel: SplitDnsViewModel =
+                                                        koinViewModel(
+                                                            parameters = { parametersOf(key.id) }
+                                                        )
+                                                    SplitDnsScreen(viewModel)
                                                 }
                                                 entry<Route.ConfigEdit> { key ->
                                                     val viewModel: ConfigEditViewModel =

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/AppDatabase.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/AppDatabase.kt
@@ -34,7 +34,7 @@ import com.zaneschepke.wireguardautotunnel.data.entity.TunnelConfig
             DnsSettings::class,
             LockdownSettings::class,
         ],
-    version = 34,
+    version = 35,
     autoMigrations =
         [
             AutoMigration(from = 1, to = 2),
@@ -67,6 +67,7 @@ import com.zaneschepke.wireguardautotunnel.data.entity.TunnelConfig
             AutoMigration(from = 31, to = 32),
             AutoMigration(from = 32, to = 33),
             AutoMigration(from = 33, to = 34, spec = SeamlessRecoveryMigration::class),
+            AutoMigration(from = 34, to = 35),
         ],
     exportSchema = true,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/DatabaseConverters.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/DatabaseConverters.kt
@@ -23,6 +23,10 @@ class DatabaseConverters {
         }
     }
 
+    @TypeConverter fun setToString(value: Set<String>): String = listToString(value.toList())
+
+    @TypeConverter fun stringToSet(value: String): Set<String> = stringToList(value).toSet()
+
     @TypeConverter
     fun mapToString(map: Map<String, String>): String {
         return Json.encodeToString(map)

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/TunnelConfig.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/TunnelConfig.kt
@@ -27,6 +27,8 @@ data class TunnelConfig(
     val ipv6RestoreEnabled: Boolean = false,
     @ColumnInfo(name = "tunnel_bssids", defaultValue = "[]")
     val tunnelBSSIDs: List<String> = emptyList(),
+    @ColumnInfo(name = "split_dns_domains", defaultValue = "[]")
+    val splitDnsDomains: Set<String> = emptySet(),
 ) {
     companion object {
         const val GLOBAL_CONFIG_NAME = "4675ab06-903a-438b-8485-6ea4187a9512"

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/TunnelConfigMapper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/TunnelConfigMapper.kt
@@ -18,6 +18,7 @@ fun Entity.toDomain(): Domain =
         isMetered = isMetered,
         ipv6RestoreEnabled = ipv6RestoreEnabled,
         tunnelBSSIDs = tunnelBSSIDs,
+        splitDnsDomains = splitDnsDomains,
     )
 
 fun Domain.toEntity(): Entity =
@@ -35,4 +36,5 @@ fun Domain.toEntity(): Entity =
         isMetered = isMetered,
         ipv6RestoreEnabled = ipv6RestoreEnabled,
         tunnelBSSIDs = tunnelBSSIDs,
+        splitDnsDomains = splitDnsDomains,
     )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/di/AppModule.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/di/AppModule.kt
@@ -25,6 +25,7 @@ import com.zaneschepke.wireguardautotunnel.viewmodel.MonitoringViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.ProxySettingsViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SettingsViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SharedAppViewModel
+import com.zaneschepke.wireguardautotunnel.viewmodel.SplitDnsViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SplitTunnelViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SupportViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.TunnelViewModel
@@ -88,6 +89,7 @@ val appModule = module {
     viewModelOf(::SettingsViewModel)
     viewModelOf(::SharedAppViewModel)
     viewModel { (id: Int) -> SplitTunnelViewModel(get(), get(), get(), id) }
+    viewModel { (id: Int) -> SplitDnsViewModel(get(), get(), id) }
     viewModel { SupportViewModel(get(), get(named(Dispatcher.MAIN)), get()) }
     viewModel { (id: Int) -> TunnelViewModel(get(), get(), id) }
 

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/TunnelConfig.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/TunnelConfig.kt
@@ -23,6 +23,7 @@ data class TunnelConfig(
     val isMetered: Boolean = false,
     val ipv6RestoreEnabled: Boolean = false,
     val tunnelBSSIDs: List<String> = emptyList(),
+    val splitDnsDomains: Set<String> = setOf(),
 ) {
 
     fun toSummary() = TunnelSummary(id = id, name = name)
@@ -55,6 +56,9 @@ data class TunnelConfig(
 
         override val isMetered: Boolean
             get() = config.isMetered
+
+        override val splitDnsDomains: Set<String>
+            get() = config.splitDnsDomains
 
         override val ipStrategy: Tunnel.IpStrategy
             get() =

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/Route.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/Route.kt
@@ -76,6 +76,13 @@ sealed class Route : NavKey {
 
     @Keep
     @Serializable
+    data class SplitDns(val id: Int) : Route(), SecureRoute {
+        override val requiresProtection: Boolean
+            get() = true
+    }
+
+    @Keep
+    @Serializable
     data class ConfigGlobal(val id: Int?) : Route(), SecureRoute {
         override val requiresProtection: Boolean
             get() = true
@@ -191,6 +198,7 @@ enum class Tab(
                 is Route.Lock,
                 is Route.Config,
                 is Route.IPv6,
+                is Route.SplitDns,
                 is Route.SplitTunnel -> TUNNELS
                 is Route.AutoTunnel,
                 Route.WifiDetectionMethod,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/components/currentBackStackEntryAsNavbarState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/components/currentBackStackEntryAsNavbarState.kt
@@ -62,6 +62,7 @@ import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.ProxySettings
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.Security
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.Settings
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.Sort
+import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.SplitDns
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.SplitTunnel
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.SplitTunnelGlobal
 import com.zaneschepke.wireguardautotunnel.ui.navigation.Route.Support
@@ -291,6 +292,25 @@ fun currentRouteAsNavbarState(
                                     )
                                 }
                         },
+                    )
+                }
+                is SplitDns -> {
+                    NavbarState(
+                        topLeading = { TvBackButton { navController.pop() } },
+                        topTitle =
+                            globalState.tunnelNames[route.id]
+                                ?: context.getString(R.string.split_dns),
+                        topTrailing = {
+                            IconButton(
+                                onClick = {
+                                    keyboardController?.hide()
+                                    sharedViewModel.postSideEffect(LocalSideEffect.SaveChanges)
+                                }
+                            ) {
+                                Icon(Icons.Rounded.Save, stringResource(R.string.save))
+                            }
+                        },
+                        showBottomItems = true,
                     )
                 }
                 is SplitTunnel,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/settings/TunnelSettingsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/settings/TunnelSettingsScreen.kt
@@ -142,6 +142,35 @@ fun TunnelSettingsScreen(
                 onClick = { navController.push(Route.SplitTunnel(id = tunnel.id)) },
             )
             SurfaceRow(
+                leading = {
+                    Icon(
+                        Icons.Outlined.Dns,
+                        contentDescription = null,
+                        tint =
+                            if (sharedUiState.tunnelMode == TunnelMode.PROXY) Disabled
+                            else MaterialTheme.colorScheme.onSurface,
+                    )
+                },
+                enabled = sharedUiState.tunnelMode != TunnelMode.PROXY,
+                title = stringResource(R.string.split_dns),
+                description = {
+                    if (sharedUiState.tunnelMode == TunnelMode.PROXY) {
+                        DescriptionText(stringResource(R.string.unavailable_in_mode), disabled = true)
+                    } else {
+                        DescriptionText(stringResource(R.string.split_dns_setting_description))
+                        if (tunnel.splitDnsDomains.isNotEmpty()) {
+                            DescriptionText(
+                                stringResource(
+                                    R.string.split_dns_domains_count,
+                                    tunnel.splitDnsDomains.size,
+                                )
+                            )
+                        }
+                    }
+                },
+                onClick = { navController.push(Route.SplitDns(id = tunnel.id)) },
+            )
+            SurfaceRow(
                 leading = { Icon(Icons.Outlined.Public, contentDescription = null) },
                 title = stringResource(R.string.ipv6_settings),
                 onClick = { navController.push(Route.IPv6(tunnel.id)) },

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/splitdns/SplitDnsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/splitdns/SplitDnsScreen.kt
@@ -1,0 +1,156 @@
+package com.zaneschepke.wireguardautotunnel.ui.screens.tunnels.splitdns
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Dns
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.zaneschepke.wireguardautotunnel.R
+import com.zaneschepke.wireguardautotunnel.util.DnsValidator
+import com.zaneschepke.wireguardautotunnel.ui.common.button.SurfaceRow
+import com.zaneschepke.wireguardautotunnel.ui.common.label.GroupLabel
+import com.zaneschepke.wireguardautotunnel.ui.common.text.DescriptionText
+import com.zaneschepke.wireguardautotunnel.ui.sideeffect.LocalSideEffect
+import com.zaneschepke.wireguardautotunnel.viewmodel.SharedAppViewModel
+import com.zaneschepke.wireguardautotunnel.viewmodel.SplitDnsViewModel
+import org.koin.compose.viewmodel.koinActivityViewModel
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SplitDnsScreen(
+    viewModel: SplitDnsViewModel,
+    sharedViewModel: SharedAppViewModel = koinActivityViewModel(),
+) {
+    val uiState by viewModel.collectAsState()
+
+    // The field text is owned locally (synchronous) so async state emissions can't reset the
+    // cursor mid-keystroke. Only committed domains flow through the view model.
+    var input by
+        rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
+
+    val submitDomain = {
+        val text = input.text
+        viewModel.addDomain(text)
+        // Clear on any valid entry (including duplicates); invalid entries stay for correction.
+        if (DnsValidator.validateDomain(text) is DnsValidator.Result.Valid) {
+            input = TextFieldValue("")
+        }
+    }
+
+    if (uiState.isLoading) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularWavyProgressIndicator(waveSpeed = 60.dp, modifier = Modifier.size(48.dp))
+        }
+        return
+    }
+
+    sharedViewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is LocalSideEffect.SaveChanges -> viewModel.save()
+            else -> Unit
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            DescriptionText(stringResource(R.string.split_dns_description))
+            if (!uiState.tunnelHasDnsServer) {
+                DescriptionText(stringResource(R.string.split_dns_no_server_warning))
+            }
+        }
+
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            OutlinedTextField(
+                value = input,
+                onValueChange = {
+                    input = it
+                    viewModel.onInputChanged()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.split_dns_add_domain)) },
+                placeholder = { Text(stringResource(R.string.split_dns_domain_hint)) },
+                singleLine = true,
+                isError = uiState.inputError != null,
+                keyboardOptions =
+                    KeyboardOptions(
+                        capitalization = KeyboardCapitalization.None,
+                        imeAction = ImeAction.Done,
+                    ),
+                keyboardActions = KeyboardActions(onDone = { submitDomain() }),
+                trailingIcon = {
+                    IconButton(onClick = { submitDomain() }) {
+                        Icon(
+                            Icons.Outlined.Add,
+                            contentDescription = stringResource(R.string.split_dns_add_domain),
+                        )
+                    }
+                },
+            )
+        }
+
+        Column {
+            GroupLabel(
+                stringResource(R.string.split_dns_domains),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            if (uiState.domains.isEmpty()) {
+                DescriptionText(
+                    stringResource(R.string.split_dns_empty),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            } else {
+                uiState.domains.forEach { domain ->
+                    SurfaceRow(
+                        leading = { Icon(Icons.Outlined.Dns, contentDescription = null) },
+                        title = domain,
+                        trailing = { modifier ->
+                            IconButton(
+                                onClick = { viewModel.removeDomain(domain) },
+                                modifier = modifier,
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Delete,
+                                    contentDescription = stringResource(R.string.remove),
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/state/SplitDnsUiState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/state/SplitDnsUiState.kt
@@ -1,0 +1,13 @@
+package com.zaneschepke.wireguardautotunnel.ui.state
+
+import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
+import com.zaneschepke.wireguardautotunnel.util.DnsError
+
+data class SplitDnsUiState(
+    val isLoading: Boolean = true,
+    val tunnel: TunnelConfig? = null,
+    val domains: List<String> = emptyList(),
+    val inputError: DnsError? = null,
+    /** True when the tunnel has no DNS server configured, so split DNS has no effect. */
+    val tunnelHasDnsServer: Boolean = true,
+)

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/DnsValidator.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/DnsValidator.kt
@@ -26,6 +26,26 @@ object DnsValidator {
         }
     }
 
+    /**
+     * Validates a split-tunnel DNS domain entry. A valid entry is a hostname with at least two
+     * labels (e.g. "example.com"); an optional leading "*." wildcard is accepted and stripped. IP
+     * addresses are rejected since matching is by name.
+     */
+    fun validateDomain(input: String?): Result {
+        val value = input?.trim()?.lowercase()?.removePrefix("*.")?.removeSuffix(".").orEmpty()
+
+        if (value.isEmpty()) return Result.Invalid(DnsError.Empty)
+        if (isValidIpv4(value)) return Result.Invalid(DnsError.InvalidIpOrHost)
+        if (!value.contains(".")) return Result.Invalid(DnsError.InvalidHost)
+        if (!isValidHostname(value)) return Result.Invalid(DnsError.InvalidIpOrHost)
+
+        return Result.Valid
+    }
+
+    /** Normalizes a domain entry for storage and matching. */
+    fun normalizeDomain(input: String): String =
+        input.trim().lowercase().removePrefix("*.").removeSuffix(".")
+
     fun validate(protocol: DnsProtocol, endpoint: String?): Result {
         if (protocol == DnsProtocol.SYSTEM) return Result.Valid
 

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SplitDnsViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SplitDnsViewModel.kt
@@ -1,0 +1,96 @@
+package com.zaneschepke.wireguardautotunnel.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.zaneschepke.wireguardautotunnel.R
+import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
+import com.zaneschepke.wireguardautotunnel.domain.repository.GlobalEffectRepository
+import com.zaneschepke.wireguardautotunnel.domain.repository.TunnelRepository
+import com.dokar.sonner.ToastType
+import com.zaneschepke.wireguardautotunnel.domain.sideeffect.GlobalSideEffect
+import com.zaneschepke.wireguardautotunnel.ui.state.SplitDnsUiState
+import com.zaneschepke.wireguardautotunnel.util.DnsValidator
+import com.zaneschepke.wireguardautotunnel.util.StringValue
+import com.zaneschepke.wireguardautotunnel.util.extensions.labelRes
+import kotlinx.coroutines.flow.map
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
+
+class SplitDnsViewModel(
+    private val tunnelRepository: TunnelRepository,
+    private val globalEffectRepository: GlobalEffectRepository,
+    val tunnelId: Int,
+) : ContainerHost<SplitDnsUiState, Nothing>, ViewModel() {
+
+    override val container =
+        container<SplitDnsUiState, Nothing>(
+            SplitDnsUiState(),
+            buildSettings = { repeatOnSubscribedStopTimeout = 5000L },
+        ) {
+            tunnelRepository.flow
+                .map { list -> list.firstOrNull { it.id == tunnelId } }
+                .collect { tunnel ->
+                    reduce {
+                        val initialized = state.tunnel != null
+                        state.copy(
+                            tunnel = tunnel,
+                            isLoading = false,
+                            tunnelHasDnsServer = tunnel?.hasDnsServer() ?: false,
+                            // Preserve in-progress edits once initialized.
+                            domains =
+                                if (initialized) state.domains
+                                else tunnel?.splitDnsDomains?.sorted().orEmpty(),
+                        )
+                    }
+                }
+        }
+
+    /** Clears any input error as the user edits; the field text itself is owned by the screen. */
+    fun onInputChanged() = intent {
+        if (state.inputError != null) reduce { state.copy(inputError = null) }
+    }
+
+    fun addDomain(rawInput: String) = intent {
+        when (val result = DnsValidator.validateDomain(rawInput)) {
+            is DnsValidator.Result.Valid -> Unit
+            is DnsValidator.Result.Invalid -> {
+                reduce { state.copy(inputError = result.error) }
+                postSideEffect(
+                    GlobalSideEffect.Snackbar(
+                        StringValue.StringResource(result.error.labelRes()),
+                        type = ToastType.Warning,
+                    )
+                )
+                return@intent
+            }
+        }
+
+        val normalized = DnsValidator.normalizeDomain(rawInput)
+        reduce {
+            if (state.domains.contains(normalized)) state
+            else state.copy(domains = (state.domains + normalized).sorted())
+        }
+    }
+
+    fun removeDomain(domain: String) = intent {
+        reduce { state.copy(domains = state.domains - domain) }
+    }
+
+    fun save() = intent {
+        val tunnel = state.tunnel ?: return@intent
+        tunnelRepository.save(tunnel.copy(splitDnsDomains = state.domains.toSet()))
+        postSideEffect(
+            GlobalSideEffect.Snackbar(
+                StringValue.StringResource(R.string.config_changes_saved),
+                type = ToastType.Success,
+            )
+        )
+        postSideEffect(GlobalSideEffect.PopBackStack)
+    }
+
+    private suspend fun postSideEffect(globalSideEffect: GlobalSideEffect) {
+        globalEffectRepository.post(globalSideEffect)
+    }
+}
+
+private fun TunnelConfig.hasDnsServer(): Boolean =
+    runCatching { getConfig().`interface`.dns?.isNotBlank() == true }.getOrDefault(false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -575,4 +575,15 @@
     <string name="snackbar_seamless_recovery_attempt">Connection issue detected. Recovering %s…</string>
     <string name="seamless_recovery_attempt_title">Seamless Recovery</string>
     <string name="seamless_recovery_attempt_message">Connection issue detected. Attempting automatic recovery.</string>
+
+    <string name="remove">Remove</string>
+    <string name="split_dns">Split DNS</string>
+    <string name="split_dns_setting_description">Resolve specific domains through the tunnel DNS server</string>
+    <string name="split_dns_description">DNS queries for the domains below are resolved through the tunnel\'s DNS server. All other queries use the device\'s default resolver. When no domains are added, all DNS traffic goes to the tunnel\'s DNS server.</string>
+    <string name="split_dns_no_server_warning">This tunnel has no DNS server configured, so split DNS has no effect until one is set in the tunnel configuration.</string>
+    <string name="split_dns_add_domain">Add domain</string>
+    <string name="split_dns_domain_hint">example.com</string>
+    <string name="split_dns_domains">Domains</string>
+    <string name="split_dns_empty">No domains added yet.</string>
+    <string name="split_dns_domains_count">%1$d domain(s)</string>
 </resources>

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/Tunnel.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/Tunnel.kt
@@ -9,6 +9,13 @@ interface Tunnel {
     val ipStrategy: IpStrategy
     val features: Set<Feature>
 
+    /**
+     * Domains whose DNS queries should be resolved through the tunnel's DNS server. When non-empty,
+     * all other DNS queries are resolved via the underlying system resolver outside the tunnel. When
+     * empty, DNS routing falls back to the default behavior (all DNS to the tunnel DNS server).
+     */
+    val splitDnsDomains: Set<String>
+
     fun updateState(state: State)
 
     sealed interface State {

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelBackend.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelBackend.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
@@ -121,7 +122,7 @@ class TunnelBackend(
                     if (hasDynamicEndpoints(mode)) {
                         pendingResolutionJobs[tunnel.id] = startTunnelBootstrapJob(tunnel, mode)
                     } else {
-                        val result = engine.start(tunnel.id, mode)
+                        val result = engine.start(tunnel.id, mode, tunnel.splitDnsDomains)
                         onEngineStartResult(tunnel.id, result)
                         if (scriptsEnabled) {
                             mode.config.`interface`.postUp?.let { runScripts(it, tunnel.id) }
@@ -173,7 +174,7 @@ class TunnelBackend(
                 is BackendMode.Proxy.KillSwitchPrimary -> mode.copy(config = resolvedConfig)
             }
 
-        val result = engine.start(tunnel.id, updatedMode)
+        val result = engine.start(tunnel.id, updatedMode, tunnel.splitDnsDomains)
         onEngineStartResult(tunnel.id, result)
         if (previousActiveConfig != null) {
             emitRecoveryEventType(tunnel.id, previousActiveConfig, resolvedConfig)
@@ -453,9 +454,30 @@ class TunnelBackend(
                     }
                 }
 
+                if (mode is BackendMode.Vpn && tunnel.splitDnsDomains.isNotEmpty()) {
+                    startSplitDnsServersJob(tunnel.id)
+                }
+
                 awaitCancellation()
             }
         }
+    }
+
+    /**
+     * Keeps the split DNS resolver's system server list in sync with the underlying network so
+     * non-matching queries keep resolving after roaming between cell and wifi. The list passed to
+     * the native layer at tunnel start is otherwise a one-time snapshot of the start-time network.
+     */
+    private fun CoroutineScope.startSplitDnsServersJob(tunnelId: Int) = launch {
+        stableNetworkEngine.stableState
+            .filterNotNull()
+            .map { it.state.underlyingDnsInfo.servers }
+            .filter { it.isNotEmpty() }
+            .distinctUntilChanged()
+            .collect { servers ->
+                val handle = byTunnelId[tunnelId] ?: return@collect
+                engine.updateSplitDnsServers(handle, servers)
+            }
     }
 
     private fun CoroutineScope.startActiveConfigJob(

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelEngine.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/TunnelEngine.kt
@@ -7,11 +7,21 @@ import com.zaneschepke.wireguardautotunnel.parser.PeerSection
 
 internal interface TunnelEngine {
 
-    suspend fun start(tunnelId: Int, mode: BackendMode): EngineStartResult
+    suspend fun start(
+        tunnelId: Int,
+        mode: BackendMode,
+        splitDnsDomains: Set<String> = emptySet(),
+    ): EngineStartResult
 
     suspend fun stop(handle: Int, mode: BackendMode)
 
     suspend fun updatePeers(handle: Int, mode: BackendMode, peers: List<PeerSection>)
 
     suspend fun getActiveConfig(handle: Int, mode: BackendMode): ActiveConfig?
+
+    /**
+     * Pushes the underlying network's DNS servers to an active VPN tunnel's split DNS resolver,
+     * e.g. after the device roams between cell and wifi. No-op for tunnels without split DNS.
+     */
+    fun updateSplitDnsServers(handle: Int, servers: List<String>)
 }

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/VpnBackend.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/VpnBackend.kt
@@ -8,7 +8,16 @@ internal object VpnBackend {
 
     external fun awgTurnOff(handle: Int)
 
-    external fun awgTurnOn(ifName: String, tunFd: Int, settings: String, uapiPath: String): Int
+    external fun awgTurnOn(
+        ifName: String,
+        tunFd: Int,
+        settings: String,
+        uapiPath: String,
+        splitDnsDomains: String,
+        splitDnsSystemServers: String,
+    ): Int
+
+    external fun awgSetSplitDnsServers(handle: Int, servers: String): Int
 
     external fun awgUpdateTunnelPeers(handle: Int, settings: String): Int
 

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/backend/WireGuardTunnelEngine.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/backend/WireGuardTunnelEngine.kt
@@ -1,5 +1,6 @@
 package com.zaneschepke.tunnel.backend
 
+import com.zaneschepke.networkmonitor.StableNetworkEngine
 import com.zaneschepke.tunnel.model.BackendMode
 import com.zaneschepke.tunnel.model.ProxyConfig
 import com.zaneschepke.tunnel.service.ServiceManager
@@ -7,14 +8,23 @@ import com.zaneschepke.tunnel.service.VpnService
 import com.zaneschepke.tunnel.state.EngineStartResult
 import com.zaneschepke.tunnel.util.BackendException
 import com.zaneschepke.tunnel.util.PortUtils
+import com.zaneschepke.tunnel.util.parseDns
 import com.zaneschepke.wireguardautotunnel.parser.ActiveConfig
 import com.zaneschepke.wireguardautotunnel.parser.Config
 import com.zaneschepke.wireguardautotunnel.parser.PeerSection
 import java.util.UUID
+import timber.log.Timber
 
-internal class WireGuardTunnelEngine(private val serviceManager: ServiceManager) : TunnelEngine {
+internal class WireGuardTunnelEngine(
+    private val serviceManager: ServiceManager,
+    private val stableNetworkEngine: StableNetworkEngine,
+) : TunnelEngine {
 
-    override suspend fun start(tunnelId: Int, mode: BackendMode): EngineStartResult {
+    override suspend fun start(
+        tunnelId: Int,
+        mode: BackendMode,
+        splitDnsDomains: Set<String>,
+    ): EngineStartResult {
 
         val ifName = WGT_INTERFACE_PREFIX + tunnelId
 
@@ -54,7 +64,12 @@ internal class WireGuardTunnelEngine(private val serviceManager: ServiceManager)
                 }
                 is BackendMode.Vpn -> {
                     val service = serviceManager.getVpnService()
-                    startVpnTunnel(ifName, mode.config, service.detachVpnTunnelFd())
+                    startVpnTunnel(
+                        splitDnsDomains,
+                        ifName,
+                        mode.config,
+                        service.detachVpnTunnelFd(),
+                    )
                 }
             }
 
@@ -125,16 +140,73 @@ internal class WireGuardTunnelEngine(private val serviceManager: ServiceManager)
         VpnBackend.awgTurnOff(handle)
     }
 
-    private fun startVpnTunnel(ifName: String, config: Config, fd: Int?): Int {
+    private fun startVpnTunnel(
+        splitDnsDomains: Set<String>,
+        ifName: String,
+        config: Config,
+        fd: Int?,
+    ): Int {
         val tunFd = fd ?: throw BackendException.Unauthorized("Failed to create tun interface")
 
+        val (splitDnsDomainsCsv, splitDnsSystemServers) = resolveSplitDns(splitDnsDomains, config)
+
         val handle =
-            VpnBackend.awgTurnOn(ifName, tunFd, config.asQuickString(), serviceManager.uapiPath)
+            VpnBackend.awgTurnOn(
+                ifName,
+                tunFd,
+                config.asQuickString(),
+                serviceManager.uapiPath,
+                splitDnsDomainsCsv,
+                splitDnsSystemServers,
+            )
         if (handle < 0) {
             throw BackendException.InternalError("Internal native error with code: $handle")
         }
         return handle
     }
+
+    /**
+     * Computes the split-tunnel DNS parameters passed to the native layer.
+     *
+     * Split DNS is only enabled when the tunnel has both a configured DNS server (an IP in the
+     * interface DNS) and a non-empty list of domains. In that case matching domains are resolved
+     * through the tunnel DNS server while all other queries are resolved against the underlying
+     * system DNS servers. Returns empty strings to disable interception (native then routes all DNS
+     * to the tunnel DNS server, the default behavior).
+     */
+    private fun resolveSplitDns(
+        splitDnsDomains: Set<String>,
+        config: Config,
+    ): Pair<String, String> {
+        if (splitDnsDomains.isEmpty()) return EMPTY_SPLIT_DNS
+
+        val hasTunnelDnsServer =
+            config.`interface`.dns?.parseDns()?.dnsServers?.isNotEmpty() == true
+        if (!hasTunnelDnsServer) {
+            Timber.w("Split DNS domains set but tunnel has no DNS server configured; ignoring")
+            return EMPTY_SPLIT_DNS
+        }
+
+        val systemServers = withDefaultServers(currentSystemDnsServers())
+
+        return splitDnsDomains.joinToString(",") to systemServers.joinToString(",")
+    }
+
+    override fun updateSplitDnsServers(handle: Int, servers: List<String>) {
+        val merged = withDefaultServers(servers)
+        val result = VpnBackend.awgSetSplitDnsServers(handle, merged.joinToString(","))
+        if (result == 0) {
+            Timber.d("Split DNS system servers updated for handle %d: %s", handle, merged)
+        }
+    }
+
+    // Public resolvers are appended as a last resort for non-matching (public) queries
+    // only; queries matching the split DNS domain list always go through the tunnel.
+    private fun withDefaultServers(servers: List<String>): List<String> =
+        (servers + DEFAULT_SYSTEM_DNS_SERVERS).distinct()
+
+    private fun currentSystemDnsServers(): List<String> =
+        stableNetworkEngine.stableState.value?.state?.underlyingDnsInfo?.servers.orEmpty()
 
     private suspend fun startProxyTunnel(
         ifName: String,
@@ -184,5 +256,9 @@ internal class WireGuardTunnelEngine(private val serviceManager: ServiceManager)
 
     companion object {
         const val WGT_INTERFACE_PREFIX = "wgtun"
+
+        private val EMPTY_SPLIT_DNS = "" to ""
+        // Public resolvers used as a last-resort fallback for non-matching (public) queries.
+        private val DEFAULT_SYSTEM_DNS_SERVERS = listOf("1.1.1.1", "8.8.8.8")
     }
 }

--- a/tunnel/src/main/java/com/zaneschepke/tunnel/di/TunnelModule.kt
+++ b/tunnel/src/main/java/com/zaneschepke/tunnel/di/TunnelModule.kt
@@ -24,7 +24,7 @@ val tunnelModule = module {
     // expect networkMonitor and NotificationProvider to be available to koin from app
     single { TunnelBackend(get(named(CoroutineScopes.IO_SCOPE)), get(), get()) } binds
         arrayOf(Backend::class, NativeTunnelCallback::class)
-    single<TunnelEngine> { WireGuardTunnelEngine(get()) }
+    single<TunnelEngine> { WireGuardTunnelEngine(get(), get()) }
 }
 
 enum class CoroutineScopes {

--- a/tunnel/tools/libwg-go/splitdns/match.go
+++ b/tunnel/tools/libwg-go/splitdns/match.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Split-tunnel DNS domain matching.
+
+package splitdns
+
+import "strings"
+
+// Matcher decides whether a queried name should be resolved through the tunnel
+// (matched) or via the underlying system resolver (not matched).
+//
+// Matching is suffix based and case insensitive: an entry "example.com" matches
+// "example.com" as well as any subdomain such as "mail.example.com" or
+// "a.b.example.com". A leading dot or "*." prefix on an entry is tolerated and
+// stripped so "*.example.com" and ".example.com" behave the same as
+// "example.com".
+type Matcher struct {
+	domains []string
+}
+
+// NewMatcher normalizes the provided domains into a Matcher. Blank entries are
+// ignored.
+func NewMatcher(domains []string) *Matcher {
+	normalized := make([]string, 0, len(domains))
+	for _, d := range domains {
+		n := normalizeDomain(d)
+		if n != "" {
+			normalized = append(normalized, n)
+		}
+	}
+	return &Matcher{domains: normalized}
+}
+
+// Empty reports whether there are no domains to match against.
+func (m *Matcher) Empty() bool {
+	return m == nil || len(m.domains) == 0
+}
+
+// Matches reports whether name should be routed through the tunnel.
+func (m *Matcher) Matches(name string) bool {
+	if m == nil {
+		return false
+	}
+	name = normalizeDomain(name)
+	if name == "" {
+		return false
+	}
+	for _, d := range m.domains {
+		if name == d || strings.HasSuffix(name, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDomain(d string) string {
+	d = strings.TrimSpace(d)
+	d = strings.ToLower(d)
+	d = strings.TrimSuffix(d, ".") // drop FQDN trailing dot
+	d = strings.TrimPrefix(d, "*.")
+	d = strings.TrimPrefix(d, ".")
+	return d
+}

--- a/tunnel/tools/libwg-go/splitdns/packet.go
+++ b/tunnel/tools/libwg-go/splitdns/packet.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal IPv4/IPv6 + UDP parsing and DNS response synthesis used by the
+// split-tunnel DNS interceptor. We hand-roll this rather than pulling in a full
+// netstack because we only ever deal with single, unfragmented UDP/53 datagrams.
+
+package splitdns
+
+import (
+	"encoding/binary"
+	"errors"
+	"net/netip"
+)
+
+const (
+	protoUDP = 17
+
+	ipv4MinHeader = 20
+	ipv6Header    = 40
+	udpHeader     = 8
+
+	dnsPort = 53
+)
+
+var errNotDNSQuery = errors.New("not a udp/53 datagram")
+
+// udpDatagram describes a parsed UDP/53 packet.
+type udpDatagram struct {
+	isV6    bool
+	srcAddr netip.Addr
+	dstAddr netip.Addr
+	srcPort uint16
+	dstPort uint16
+	payload []byte // DNS message bytes (slice into the original buffer)
+}
+
+// parseDNSQuery parses an IP packet and returns the contained UDP/53 datagram.
+// It returns errNotDNSQuery for anything that is not an unfragmented UDP packet
+// destined for port 53.
+func parseDNSQuery(pkt []byte) (*udpDatagram, error) {
+	if len(pkt) < 1 {
+		return nil, errNotDNSQuery
+	}
+	switch pkt[0] >> 4 {
+	case 4:
+		return parseV4(pkt)
+	case 6:
+		return parseV6(pkt)
+	default:
+		return nil, errNotDNSQuery
+	}
+}
+
+func parseV4(pkt []byte) (*udpDatagram, error) {
+	if len(pkt) < ipv4MinHeader {
+		return nil, errNotDNSQuery
+	}
+	ihl := int(pkt[0]&0x0f) * 4
+	if ihl < ipv4MinHeader || len(pkt) < ihl {
+		return nil, errNotDNSQuery
+	}
+	if pkt[9] != protoUDP {
+		return nil, errNotDNSQuery
+	}
+	// Fragmented packets (offset != 0 or MF set) are ignored.
+	fragField := binary.BigEndian.Uint16(pkt[6:8])
+	if fragField&0x1fff != 0 || fragField&0x2000 != 0 {
+		return nil, errNotDNSQuery
+	}
+	src, _ := netip.AddrFromSlice(pkt[12:16])
+	dst, _ := netip.AddrFromSlice(pkt[16:20])
+	return parseUDP(pkt[ihl:], false, src, dst)
+}
+
+func parseV6(pkt []byte) (*udpDatagram, error) {
+	if len(pkt) < ipv6Header {
+		return nil, errNotDNSQuery
+	}
+	// Only handle packets where UDP is the first (and only) header.
+	if pkt[6] != protoUDP {
+		return nil, errNotDNSQuery
+	}
+	src, _ := netip.AddrFromSlice(pkt[8:24])
+	dst, _ := netip.AddrFromSlice(pkt[24:40])
+	return parseUDP(pkt[ipv6Header:], true, src, dst)
+}
+
+func parseUDP(seg []byte, isV6 bool, src, dst netip.Addr) (*udpDatagram, error) {
+	if len(seg) < udpHeader {
+		return nil, errNotDNSQuery
+	}
+	dstPort := binary.BigEndian.Uint16(seg[2:4])
+	if dstPort != dnsPort {
+		return nil, errNotDNSQuery
+	}
+	length := int(binary.BigEndian.Uint16(seg[4:6]))
+	if length < udpHeader || length > len(seg) {
+		length = len(seg)
+	}
+	return &udpDatagram{
+		isV6:    isV6,
+		srcAddr: src,
+		dstAddr: dst,
+		srcPort: binary.BigEndian.Uint16(seg[0:2]),
+		dstPort: dstPort,
+		payload: seg[udpHeader:length],
+	}, nil
+}
+
+// buildResponse synthesizes an IP+UDP packet carrying dnsPayload, addressed back
+// to the original querier. Source/destination are swapped relative to the
+// incoming query so the app sees a reply from the DNS server it queried.
+func buildResponse(q *udpDatagram, dnsPayload []byte) []byte {
+	udpLen := udpHeader + len(dnsPayload)
+	if q.isV6 {
+		return buildV6(q, dnsPayload, udpLen)
+	}
+	return buildV4(q, dnsPayload, udpLen)
+}
+
+func buildV4(q *udpDatagram, dnsPayload []byte, udpLen int) []byte {
+	total := ipv4MinHeader + udpLen
+	pkt := make([]byte, total)
+
+	pkt[0] = 0x45 // version 4, IHL 5
+	pkt[1] = 0x00 // DSCP/ECN
+	binary.BigEndian.PutUint16(pkt[2:4], uint16(total))
+	// identification, flags, fragment offset all left zero
+	pkt[8] = 64 // TTL
+	pkt[9] = protoUDP
+	// reply src = original dst, reply dst = original src
+	copy(pkt[12:16], q.dstAddr.AsSlice())
+	copy(pkt[16:20], q.srcAddr.AsSlice())
+	binary.BigEndian.PutUint16(pkt[10:12], checksum(pkt[:ipv4MinHeader]))
+
+	writeUDP(pkt[ipv4MinHeader:], q, dnsPayload, udpLen, false)
+	return pkt
+}
+
+func buildV6(q *udpDatagram, dnsPayload []byte, udpLen int) []byte {
+	total := ipv6Header + udpLen
+	pkt := make([]byte, total)
+
+	pkt[0] = 0x60 // version 6
+	binary.BigEndian.PutUint16(pkt[4:6], uint16(udpLen))
+	pkt[6] = protoUDP // next header
+	pkt[7] = 64       // hop limit
+	copy(pkt[8:24], q.dstAddr.AsSlice())
+	copy(pkt[24:40], q.srcAddr.AsSlice())
+
+	writeUDP(pkt[ipv6Header:], q, dnsPayload, udpLen, true)
+	return pkt
+}
+
+func writeUDP(seg []byte, q *udpDatagram, dnsPayload []byte, udpLen int, isV6 bool) {
+	// reply src port = original dst port (53), reply dst port = original src port
+	binary.BigEndian.PutUint16(seg[0:2], q.dstPort)
+	binary.BigEndian.PutUint16(seg[2:4], q.srcPort)
+	binary.BigEndian.PutUint16(seg[4:6], uint16(udpLen))
+	copy(seg[udpHeader:], dnsPayload)
+
+	// reply src addr = original dst addr, reply dst addr = original src addr
+	sum := udpChecksum(q.dstAddr, q.srcAddr, seg[:udpLen], isV6)
+	binary.BigEndian.PutUint16(seg[6:8], sum)
+}
+
+// checksum computes the 16-bit one's complement checksum used by IPv4 headers.
+func checksum(b []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(b[i : i+2]))
+	}
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// udpChecksum computes the UDP checksum including the IPv4/IPv6 pseudo-header.
+func udpChecksum(src, dst netip.Addr, udpSeg []byte, isV6 bool) uint16 {
+	var sum uint32
+
+	srcB := src.AsSlice()
+	dstB := dst.AsSlice()
+	for i := 0; i+1 < len(srcB); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(srcB[i : i+2]))
+	}
+	for i := 0; i+1 < len(dstB); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(dstB[i : i+2]))
+	}
+
+	if isV6 {
+		sum += uint32(len(udpSeg)) // upper-layer length (fits in 16 bits here)
+		sum += uint32(protoUDP)
+	} else {
+		sum += uint32(protoUDP)
+		sum += uint32(len(udpSeg))
+	}
+
+	for i := 0; i+1 < len(udpSeg); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(udpSeg[i : i+2]))
+	}
+	if len(udpSeg)%2 == 1 {
+		sum += uint32(udpSeg[len(udpSeg)-1]) << 8
+	}
+
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	csum := ^uint16(sum)
+	if csum == 0 {
+		csum = 0xffff // a zero checksum is transmitted as all ones
+	}
+	return csum
+}

--- a/tunnel/tools/libwg-go/splitdns/splitdns.go
+++ b/tunnel/tools/libwg-go/splitdns/splitdns.go
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Package splitdns implements per-domain split-tunnel DNS for the VPN backend.
+//
+// It wraps the OS tun.Device that sits underneath the wireguard device. Outbound
+// DNS queries (UDP/53) are inspected: queries whose name matches the configured
+// domain list are passed straight through so they are resolved by the tunnel's
+// DNS server (over the tunnel), while all other queries are resolved locally
+// against the underlying system DNS servers using a tunnel-bypassing socket and
+// answered directly. Non-DNS traffic is untouched.
+package splitdns
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/amnezia-vpn/amneziawg-go/tun"
+	"github.com/miekg/dns"
+)
+
+const (
+	resolveTimeout  = 5 * time.Second
+	// Per-server slice of the overall budget. UDP "dials" succeed instantly even
+	// toward unreachable addresses, so without this a single dead server would
+	// consume the entire resolveTimeout in its read and starve every fallback.
+	perServerTimeout = 2 * time.Second
+	maxInFlight      = 64
+	maxResponseSize  = 65535
+)
+
+// LogFunc is a logging hook. The caller wires these to the platform logger;
+// they default to no-ops so this package builds without any cgo dependency.
+type LogFunc func(format string, args ...any)
+
+var (
+	logDebug LogFunc = func(string, ...any) {}
+	logError LogFunc = func(string, ...any) {}
+)
+
+// SetLoggers installs debug/error logging hooks for the package.
+func SetLoggers(debug, errorf LogFunc) {
+	if debug != nil {
+		logDebug = debug
+	}
+	if errorf != nil {
+		logError = errorf
+	}
+}
+
+// ContextDialer dials connections. *net.Dialer satisfies it; callers pass a
+// dialer configured to bypass the tunnel (protected socket).
+type ContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Device wraps an inner tun.Device, intercepting non-matching DNS queries.
+// Methods we do not customize (File, MTU, Name, Events, BatchSize) promote
+// through the embedded tun.Device.
+type Device struct {
+	tun.Device
+
+	matcher *Matcher
+	dialer  ContextDialer
+
+	serversMu sync.RWMutex
+	servers   []string
+
+	writeMu sync.Mutex
+	sem     chan struct{}
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewDevice wraps inner so that DNS queries not matching the configured domains
+// are resolved against the system DNS servers via the bypassing dialer.
+func NewDevice(inner tun.Device, matcher *Matcher, systemServers []string, dialer ContextDialer) *Device {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Device{
+		Device:  inner,
+		matcher: matcher,
+		servers: normalizeServers(systemServers),
+		dialer:  dialer,
+		sem:     make(chan struct{}, maxInFlight),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+// SetServers replaces the system DNS server list, e.g. after the underlying
+// network changes. It only affects where non-matching queries are resolved;
+// queries matching the split domain list always pass through to the tunnel.
+func (d *Device) SetServers(servers []string) {
+	normalized := normalizeServers(servers)
+	d.serversMu.Lock()
+	d.servers = normalized
+	d.serversMu.Unlock()
+	logDebug("system DNS servers updated: %v", normalized)
+}
+
+func (d *Device) currentServers() []string {
+	d.serversMu.RLock()
+	defer d.serversMu.RUnlock()
+	return d.servers
+}
+
+func normalizeServers(servers []string) []string {
+	out := make([]string, 0, len(servers))
+	for _, s := range servers {
+		if _, _, err := net.SplitHostPort(s); err != nil {
+			s = net.JoinHostPort(s, "53")
+		} else {
+			// Clone entries we keep as-is: callers may pass strings that alias a
+			// borrowed cgo/JNI buffer which is freed after the call returns.
+			s = strings.Clone(s)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// Read pulls packets from the inner device, intercepting DNS queries that should
+// be resolved outside the tunnel. Intercepted queries are removed from the batch
+// returned to the wireguard device and handled asynchronously.
+func (d *Device) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	for {
+		n, err := d.Device.Read(bufs, sizes, offset)
+		if err != nil || n == 0 {
+			return n, err
+		}
+
+		w := 0
+		for i := 0; i < n; i++ {
+			pkt := bufs[i][offset : offset+sizes[i]]
+			if d.intercept(pkt) {
+				continue
+			}
+			if w != i {
+				copy(bufs[w][offset:], bufs[i][offset:offset+sizes[i]])
+				sizes[w] = sizes[i]
+			}
+			w++
+		}
+
+		if w > 0 {
+			return w, nil
+		}
+		// Every packet in this batch was intercepted; read again rather than
+		// returning zero packets to the device read loop.
+	}
+}
+
+// intercept returns true if pkt was a non-matching DNS query that we took
+// ownership of (and therefore must be dropped from the wireguard read path).
+func (d *Device) intercept(pkt []byte) bool {
+	q, err := parseDNSQuery(pkt)
+	if err != nil {
+		return false
+	}
+
+	name, ok := questionName(q.payload)
+	if !ok {
+		// Unparseable DNS — let it flow to the tunnel resolver.
+		return false
+	}
+
+	if d.matcher.Matches(name) {
+		return false // resolve through the tunnel
+	}
+
+	// Copy the query bytes; the underlying buffer is reused by the read loop.
+	query := make([]byte, len(q.payload))
+	copy(query, q.payload)
+	meta := *q
+	meta.payload = query
+
+	select {
+	case d.sem <- struct{}{}:
+		go d.resolveAndReply(&meta)
+		return true
+	default:
+		// Too many in-flight resolutions; fall back to tunnel resolution.
+		logDebug("resolver saturated, passing %s to tunnel", name)
+		return false
+	}
+}
+
+func questionName(payload []byte) (string, bool) {
+	var msg dns.Msg
+	if err := msg.Unpack(payload); err != nil {
+		return "", false
+	}
+	if len(msg.Question) == 0 {
+		return "", false
+	}
+	return msg.Question[0].Name, true
+}
+
+// buildServfail builds a SERVFAIL response to the given DNS query payload.
+func buildServfail(query []byte) ([]byte, bool) {
+	var req dns.Msg
+	if err := req.Unpack(query); err != nil {
+		return nil, false
+	}
+	var res dns.Msg
+	res.SetRcode(&req, dns.RcodeServerFailure)
+	out, err := res.Pack()
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func (d *Device) resolveAndReply(q *udpDatagram) {
+	defer func() { <-d.sem }()
+
+	reply, err := d.resolve(q.payload)
+	if err != nil {
+		logError("failed to resolve via system DNS: %v", err)
+		// Answer SERVFAIL instead of dropping so the client fails fast and
+		// retries (by which point the server list may have been refreshed).
+		// Only non-matching queries ever reach this path, so no query for a
+		// split-listed (internal) domain is exposed or answered here.
+		servfail, ok := buildServfail(q.payload)
+		if !ok {
+			return
+		}
+		reply = servfail
+	}
+
+	pkt := buildResponse(q, reply)
+
+	// Offset 0 is correct for the Android VpnService tun, which is created without
+	// IFF_VNET_HDR, so NativeTun.Write writes each buffer from index 0 with no
+	// virtio header headroom.
+	d.writeMu.Lock()
+	_, err = d.Device.Write([][]byte{pkt}, 0)
+	d.writeMu.Unlock()
+	if err != nil {
+		logError("failed to write DNS reply: %v", err)
+	}
+}
+
+func (d *Device) resolve(query []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(d.ctx, resolveTimeout)
+	defer cancel()
+
+	var lastErr error
+	for _, server := range d.currentServers() {
+		serverCtx, serverCancel := context.WithTimeout(ctx, perServerTimeout)
+		reply, err := d.exchangeWith(serverCtx, server, query)
+		serverCancel()
+		if err == nil {
+			return reply, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = net.ErrClosed
+	}
+	return nil, lastErr
+}
+
+func (d *Device) exchangeWith(ctx context.Context, server string, query []byte) ([]byte, error) {
+	conn, err := d.dialer.DialContext(ctx, "udp", server)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return exchange(ctx, conn, query)
+}
+
+func exchange(ctx context.Context, conn net.Conn, query []byte) ([]byte, error) {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if _, err := conn.Write(query); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, maxResponseSize)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// Write forwards to the inner device under the same lock used for synthesized
+// DNS replies so concurrent writes do not interleave.
+func (d *Device) Write(bufs [][]byte, offset int) (int, error) {
+	d.writeMu.Lock()
+	defer d.writeMu.Unlock()
+	return d.Device.Write(bufs, offset)
+}
+
+// Close cancels in-flight resolutions and closes the inner device.
+func (d *Device) Close() error {
+	d.cancel()
+	return d.Device.Close()
+}

--- a/tunnel/tools/libwg-go/splitdns/splitdns_test.go
+++ b/tunnel/tools/libwg-go/splitdns/splitdns_test.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package splitdns
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestMatcherSuffix(t *testing.T) {
+	m := NewMatcher([]string{"example.com", "*.internal.corp", ".foo.net", "EXAMPLE.ORG."})
+
+	cases := map[string]bool{
+		"example.com":          true,
+		"mail.example.com":     true,
+		"a.b.example.com":      true,
+		"notexample.com":       false, // not a label-boundary suffix
+		"example.com.evil.com": false,
+		"x.internal.corp":      true,
+		"internal.corp":        true,
+		"foo.net":              true,
+		"www.foo.net":          true,
+		"example.org":          true,
+		"sub.example.org":      true,
+		"google.com":           false,
+	}
+
+	for name, want := range cases {
+		if got := m.Matches(name); got != want {
+			t.Errorf("Matches(%q) = %v, want %v", name, got, want)
+		}
+		// FQDN form (trailing dot) must behave identically.
+		if got := m.Matches(name + "."); got != want {
+			t.Errorf("Matches(%q.) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestEmptyMatcherMatchesNothing(t *testing.T) {
+	m := NewMatcher(nil)
+	if !m.Empty() {
+		t.Fatal("expected empty matcher")
+	}
+	if m.Matches("example.com") {
+		t.Error("empty matcher should not match")
+	}
+}
+
+// buildQuery assembles an IPv4/IPv6 UDP/53 query packet for a name.
+func buildQuery(t *testing.T, isV6 bool, name string) ([]byte, []byte) {
+	t.Helper()
+	var msg dns.Msg
+	msg.SetQuestion(dns.Fqdn(name), dns.TypeA)
+	payload, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	udpLen := udpHeader + len(payload)
+	var src, dst netip.Addr
+	var pkt []byte
+	if isV6 {
+		src = netip.MustParseAddr("fd00::2")
+		dst = netip.MustParseAddr("fd00::1")
+		pkt = make([]byte, ipv6Header+udpLen)
+		pkt[0] = 0x60
+		binary.BigEndian.PutUint16(pkt[4:6], uint16(udpLen))
+		pkt[6] = protoUDP
+		pkt[7] = 64
+		copy(pkt[8:24], src.AsSlice())
+		copy(pkt[24:40], dst.AsSlice())
+		seg := pkt[ipv6Header:]
+		binary.BigEndian.PutUint16(seg[0:2], 12345) // src port
+		binary.BigEndian.PutUint16(seg[2:4], dnsPort)
+		binary.BigEndian.PutUint16(seg[4:6], uint16(udpLen))
+		copy(seg[udpHeader:], payload)
+		binary.BigEndian.PutUint16(seg[6:8], udpChecksum(src, dst, seg[:udpLen], true))
+	} else {
+		src = netip.MustParseAddr("10.0.0.2")
+		dst = netip.MustParseAddr("10.0.0.1")
+		pkt = make([]byte, ipv4MinHeader+udpLen)
+		pkt[0] = 0x45
+		binary.BigEndian.PutUint16(pkt[2:4], uint16(len(pkt)))
+		pkt[8] = 64
+		pkt[9] = protoUDP
+		copy(pkt[12:16], src.AsSlice())
+		copy(pkt[16:20], dst.AsSlice())
+		binary.BigEndian.PutUint16(pkt[10:12], checksum(pkt[:ipv4MinHeader]))
+		seg := pkt[ipv4MinHeader:]
+		binary.BigEndian.PutUint16(seg[0:2], 12345)
+		binary.BigEndian.PutUint16(seg[2:4], dnsPort)
+		binary.BigEndian.PutUint16(seg[4:6], uint16(udpLen))
+		copy(seg[udpHeader:], payload)
+		binary.BigEndian.PutUint16(seg[6:8], udpChecksum(src, dst, seg[:udpLen], false))
+	}
+	return pkt, payload
+}
+
+func TestParseAndQuestionName(t *testing.T) {
+	for _, isV6 := range []bool{false, true} {
+		pkt, payload := buildQuery(t, isV6, "mail.example.com")
+		q, err := parseDNSQuery(pkt)
+		if err != nil {
+			t.Fatalf("isV6=%v parse: %v", isV6, err)
+		}
+		if q.isV6 != isV6 {
+			t.Errorf("isV6=%v: got %v", isV6, q.isV6)
+		}
+		if q.dstPort != dnsPort {
+			t.Errorf("dstPort = %d", q.dstPort)
+		}
+		if string(q.payload) != string(payload) {
+			t.Errorf("payload mismatch")
+		}
+		name, ok := questionName(q.payload)
+		if !ok || name != "mail.example.com." {
+			t.Errorf("questionName = %q, ok=%v", name, ok)
+		}
+	}
+}
+
+func TestParseRejectsNonDNS(t *testing.T) {
+	// TCP packet (proto 6) must be rejected.
+	pkt := make([]byte, ipv4MinHeader+8)
+	pkt[0] = 0x45
+	pkt[9] = 6
+	if _, err := parseDNSQuery(pkt); err == nil {
+		t.Error("expected non-DNS packet to be rejected")
+	}
+	// Non port-53 UDP must be rejected.
+	pkt2, _ := buildQuery(t, false, "x.com")
+	binary.BigEndian.PutUint16(pkt2[ipv4MinHeader+2:ipv4MinHeader+4], 443)
+	if _, err := parseDNSQuery(pkt2); err == nil {
+		t.Error("expected non-53 UDP to be rejected")
+	}
+}
+
+// verifyChecksums recomputes header/UDP checksums of a built packet and ensures
+// they validate to zero (the standard correctness check).
+func TestBuildResponseChecksums(t *testing.T) {
+	for _, isV6 := range []bool{false, true} {
+		pkt, _ := buildQuery(t, isV6, "example.com")
+		q, err := parseDNSQuery(pkt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var ans dns.Msg
+		ans.SetQuestion(dns.Fqdn("example.com"), dns.TypeA)
+		ans.Response = true
+		ans.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: dns.Fqdn("example.com"), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   netip.MustParseAddr("93.184.216.34").AsSlice(),
+		}}
+		reply, _ := ans.Pack()
+
+		resp := buildResponse(q, reply)
+		rq, err := parseDNSQuery(resp)
+		// parseDNSQuery requires dst port 53; the response has dst port = original
+		// src (12345), so parse it manually for verification instead.
+		_ = rq
+		_ = err
+
+		if isV6 {
+			seg := resp[ipv6Header:]
+			src := netip.MustParseAddr("fd00::1") // reply src = original dst
+			dst := netip.MustParseAddr("fd00::2")
+			if got := udpChecksum(src, dst, seg, true); got != 0 && got != 0xffff {
+				t.Errorf("v6 udp checksum validation = %d, want 0/0xffff", got)
+			}
+			// reply src port must be 53, dst port the original 12345
+			if binary.BigEndian.Uint16(seg[0:2]) != dnsPort {
+				t.Errorf("v6 reply src port = %d", binary.BigEndian.Uint16(seg[0:2]))
+			}
+		} else {
+			if got := checksum(resp[:ipv4MinHeader]); got != 0 {
+				t.Errorf("v4 ip checksum validation = %d, want 0", got)
+			}
+			seg := resp[ipv4MinHeader:]
+			src := netip.MustParseAddr("10.0.0.1")
+			dst := netip.MustParseAddr("10.0.0.2")
+			if got := udpChecksum(src, dst, seg, false); got != 0 && got != 0xffff {
+				t.Errorf("v4 udp checksum validation = %d, want 0/0xffff", got)
+			}
+			if binary.BigEndian.Uint16(seg[0:2]) != dnsPort {
+				t.Errorf("v4 reply src port = %d", binary.BigEndian.Uint16(seg[0:2]))
+			}
+		}
+	}
+}
+
+func TestBuildServfail(t *testing.T) {
+	var q dns.Msg
+	q.SetQuestion("example.com.", dns.TypeA)
+	q.Id = 0xbeef
+	query, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	out, ok := buildServfail(query)
+	if !ok {
+		t.Fatal("buildServfail failed on valid query")
+	}
+
+	var res dns.Msg
+	if err := res.Unpack(out); err != nil {
+		t.Fatalf("unpack response: %v", err)
+	}
+	if res.Id != q.Id {
+		t.Errorf("response id = %#x, want %#x", res.Id, q.Id)
+	}
+	if res.Rcode != dns.RcodeServerFailure {
+		t.Errorf("rcode = %d, want SERVFAIL", res.Rcode)
+	}
+	if !res.Response {
+		t.Error("QR bit not set")
+	}
+	if len(res.Question) != 1 || res.Question[0].Name != "example.com." {
+		t.Errorf("question not echoed: %v", res.Question)
+	}
+
+	if _, ok := buildServfail([]byte{0x01, 0x02}); ok {
+		t.Error("buildServfail should fail on garbage input")
+	}
+}
+
+func TestNormalizeServers(t *testing.T) {
+	got := normalizeServers([]string{"10.0.0.1", "1.1.1.1:5353", "fd00::9", "[fd00::9]:53"})
+	want := []string{"10.0.0.1:53", "1.1.1.1:5353", "[fd00::9]:53", "[fd00::9]:53"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("normalizeServers[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// recordingDialer fails every dial but records the addresses tried.
+type recordingDialer struct {
+	mu    sync.Mutex
+	addrs []string
+}
+
+func (r *recordingDialer) DialContext(_ context.Context, _, address string) (net.Conn, error) {
+	r.mu.Lock()
+	r.addrs = append(r.addrs, address)
+	r.mu.Unlock()
+	return nil, net.ErrClosed
+}
+
+func TestSetServersTakesEffect(t *testing.T) {
+	dialer := &recordingDialer{}
+	d := NewDevice(nil, NewMatcher([]string{"internal.corp"}), []string{"10.0.0.1"}, dialer)
+	defer d.cancel()
+
+	if _, err := d.resolve([]byte{0}); err == nil {
+		t.Fatal("expected resolve to fail with failing dialer")
+	}
+	d.SetServers([]string{"192.168.1.1", "1.1.1.1"})
+	if _, err := d.resolve([]byte{0}); err == nil {
+		t.Fatal("expected resolve to fail with failing dialer")
+	}
+
+	want := []string{"10.0.0.1:53", "192.168.1.1:53", "1.1.1.1:53"}
+	dialer.mu.Lock()
+	defer dialer.mu.Unlock()
+	if len(dialer.addrs) != len(want) {
+		t.Fatalf("dialed %v, want %v", dialer.addrs, want)
+	}
+	for i := range want {
+		if dialer.addrs[i] != want[i] {
+			t.Errorf("dial[%d] = %q, want %q", i, dialer.addrs[i], want[i])
+		}
+	}
+}

--- a/tunnel/tools/libwg-go/vpn/vpn.go
+++ b/tunnel/tools/libwg-go/vpn/vpn.go
@@ -20,13 +20,44 @@ import (
 	"github.com/amnezia-vpn/amneziawg-go/ipc"
 	"github.com/amnezia-vpn/amneziawg-go/tun"
 	wireproxyawg "github.com/artem-russkikh/wireproxy-awg"
+	"github.com/wgtunnel/android/dns"
 	"github.com/wgtunnel/android/shared"
+	"github.com/wgtunnel/android/splitdns"
 	"golang.org/x/sys/unix"
 )
 
+func init() {
+	// Route splitdns logging through the shared platform logger.
+	splitdns.SetLoggers(
+		func(format string, args ...any) { shared.LogDebug("SplitDNS", format, args...) },
+		func(format string, args ...any) { shared.LogError("SplitDNS", format, args...) },
+	)
+}
+
+// splitCSV splits a comma-separated list, trimming whitespace and dropping
+// empty entries.
+//
+// Each entry is cloned. The caller passes strings that originate from a cgo
+// //export parameter, which aliases the JNI GetStringUTFChars buffer rather than
+// copying it. That buffer is released as soon as awgTurnOn returns, but the split
+// DNS matcher retains these entries for the tunnel's lifetime, so they must own
+// their backing memory. strings.Split/TrimSpace alone return sub-slices of the
+// borrowed buffer, hence the explicit Clone.
+func splitCSV(s string) []string {
+	out := make([]string, 0)
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, strings.Clone(part))
+		}
+	}
+	return out
+}
+
 type TunnelHandle struct {
-	device *device.Device
-	uapi   net.Listener
+	device   *device.Device
+	uapi     net.Listener
+	splitDns *splitdns.Device
 }
 
 var (
@@ -41,12 +72,28 @@ func init() {
 }
 
 //export awgTurnOn
-func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath string) int32 {
-	tunnel, name, err := tun.CreateUnmonitoredTUNFromFD(int(tunFd))
+func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath string, splitDnsDomains string, splitDnsSystemServers string) int32 {
+	tunDev, name, err := tun.CreateUnmonitoredTUNFromFD(int(tunFd))
+
 	if err != nil {
 		unix.Close(int(tunFd))
 		shared.LogError(tag, "CreateUnmonitoredTUNFromFD: %v", err)
 		return -1
+	}
+
+	var tunnel tun.Device = tunDev
+	var splitDnsDev *splitdns.Device
+
+	if domains := splitCSV(splitDnsDomains); len(domains) > 0 {
+		servers := splitCSV(splitDnsSystemServers)
+		shared.LogDebug(tag, "Enabling split DNS for %d domain(s), system servers=%v", len(domains), servers)
+		splitDnsDev = splitdns.NewDevice(
+			tunDev,
+			splitdns.NewMatcher(domains),
+			servers,
+			dns.GetDialer(true),
+		)
+		tunnel = splitDnsDev
 	}
 
 	conf, err := wireproxyawg.ParseConfigString(settings)
@@ -140,11 +187,29 @@ func awgTurnOn(interfaceName string, tunFd int32, settings string, uapiPath stri
 
 	tunnelMu.Lock()
 	tunnelHandles[handle] = TunnelHandle{
-		device: tunDevice,
-		uapi:   uapi,
+		device:   tunDevice,
+		uapi:     uapi,
+		splitDns: splitDnsDev,
 	}
 	tunnelMu.Unlock()
 	return handle
+}
+
+//export awgSetSplitDnsServers
+func awgSetSplitDnsServers(tunnelHandle int32, servers string) int32 {
+	tunnelMu.RLock()
+	handle, ok := tunnelHandles[tunnelHandle]
+	tunnelMu.RUnlock()
+	if !ok {
+		shared.LogError(tag, "awgSetSplitDnsServers: tunnel is not up")
+		return -1
+	}
+	if handle.splitDns == nil {
+		return -1
+	}
+	// splitCSV clones each entry out of the borrowed JNI string buffer.
+	handle.splitDns.SetServers(splitCSV(servers))
+	return 0
 }
 
 //export awgUpdateTunnelPeers

--- a/tunnel/tools/libwg-go/vpn/vpn_jni.c
+++ b/tunnel/tools/libwg-go/vpn/vpn_jni.c
@@ -13,15 +13,16 @@ struct go_string {
     long n;
 };
 
-extern int awgTurnOn(struct go_string ifname, int tun_fd, struct go_string settings, struct go_string uapipath);
+extern int awgTurnOn(struct go_string ifname, int tun_fd, struct go_string settings, struct go_string uapipath, struct go_string split_dns_domains, struct go_string split_dns_system_servers);
 extern void awgTurnOff(int handle);
 extern char *awgGetConfig(int handle);
 extern char *awgVersion();
 extern int awgUpdateTunnelPeers(int handle, struct go_string settings);
+extern int awgSetSplitDnsServers(int handle, struct go_string servers);
 
 JNIEXPORT jint JNICALL
 Java_com_zaneschepke_tunnel_backend_VpnBackend_awgTurnOn(
-        JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings, jstring uapipath)
+        JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings, jstring uapipath, jstring split_dns_domains, jstring split_dns_system_servers)
 {
     const char *ifname_str = (*env)->GetStringUTFChars(env, ifname, 0);
     size_t ifname_len = (*env)->GetStringUTFLength(env, ifname);
@@ -32,6 +33,12 @@ Java_com_zaneschepke_tunnel_backend_VpnBackend_awgTurnOn(
     const char *uapipath_str = (*env)->GetStringUTFChars(env, uapipath, 0);
     size_t uapipath_len = (*env)->GetStringUTFLength(env, uapipath);
 
+    const char *split_domains_str = (*env)->GetStringUTFChars(env, split_dns_domains, 0);
+    size_t split_domains_len = (*env)->GetStringUTFLength(env, split_dns_domains);
+
+    const char *split_servers_str = (*env)->GetStringUTFChars(env, split_dns_system_servers, 0);
+    size_t split_servers_len = (*env)->GetStringUTFLength(env, split_dns_system_servers);
+
     int ret = awgTurnOn((struct go_string){
             .str = ifname_str,
             .n = ifname_len
@@ -41,11 +48,19 @@ Java_com_zaneschepke_tunnel_backend_VpnBackend_awgTurnOn(
     }, (struct go_string){
             .str = uapipath_str,
             .n = uapipath_len
+    }, (struct go_string){
+            .str = split_domains_str,
+            .n = split_domains_len
+    }, (struct go_string){
+            .str = split_servers_str,
+            .n = split_servers_len
     });
 
     (*env)->ReleaseStringUTFChars(env, ifname, ifname_str);
     (*env)->ReleaseStringUTFChars(env, settings, settings_str);
     (*env)->ReleaseStringUTFChars(env, uapipath, uapipath_str);
+    (*env)->ReleaseStringUTFChars(env, split_dns_domains, split_domains_str);
+    (*env)->ReleaseStringUTFChars(env, split_dns_system_servers, split_servers_str);
 
     return ret;
 }
@@ -79,6 +94,22 @@ Java_com_zaneschepke_tunnel_backend_VpnBackend_awgVersion(JNIEnv *env, jclass c)
 
     jstring ret = (*env)->NewStringUTF(env, version);
     free(version);
+    return ret;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_zaneschepke_tunnel_backend_VpnBackend_awgSetSplitDnsServers(
+        JNIEnv *env, jclass c, jint handle, jstring servers)
+{
+    const char *servers_str = (*env)->GetStringUTFChars(env, servers, 0);
+    size_t servers_len = (*env)->GetStringUTFLength(env, servers);
+
+    int ret = awgSetSplitDnsServers(handle, (struct go_string){
+            .str = servers_str,
+            .n = servers_len
+    });
+
+    (*env)->ReleaseStringUTFChars(env, servers, servers_str);
     return ret;
 }
 


### PR DESCRIPTION
Two up front disclaimers on this:
1. I've been using this code for about a month or two on my and my wife's Pixel 8 Pro to make sure there were no obvious issues before opening a PR (one I ran into early on was needing to keep track of provider DNS changes, especially when switching from cellular with IPv6 to wifi). I see there's another PR where you mentioned you're already planning something similar, but I figured I'd add my material for you to pull from if it helps. I took a slightly different approach by having a per-tunnel dialog to define the list of domains/prefixes that would be sent through to the tunnel's resolver. I'm not trying to step on any toes nor will my feelings be hurt if this gets closed (I actually expect it to be), just trying to support the effort if I can!
2. This code was fully written by Claude Code - I had a need and was super grateful that you had open sourced this awesome app so I could get something functional :-) Thank you!

**What**
Adds per-tunnel split DNS: queries for a configured list of domains resolve through the tunnel's DNS server; all other queries go to the device's underlying system resolver. Addresses #572.

**How**
A tun.Device wrapper in libwg-go inspects outbound UDP/53 before the WireGuard device: matching (case-insensitive suffix) queries pass through to the tunnel DNS; non-matching queries resolve out-of-band against system DNS via a tunnel-bypassing socket and are answered directly (SERVFAIL on failure so clients don't hang). The system resolver list refreshes on network changes, so it survives cell/Wi-Fi roaming. Unchanged behavior when a tunnel has a DNS server but no split domains.

**UI/persistence**
New per-tunnel Split DNS screen with validation; splitDnsDomains stored via Room (v35 auto-migration).

**Testing**
Go unit tests (matcher, v4/v6 packet parse/synthesis, server updates); manually verified on Pixel 8 Pro / Android 16 incl. roaming.

**Relationship to existing work**
Overlaps @erikeah's draft #1341 and issue #572 (same "DNS-filtering tun wrapper" approach). Differences here: intercepts all UDP/53 (vs a sentinel IP), dedicated per-tunnel domain-list UI + DB column (vs ~ tokens in DNS =), and IPv4/IPv6 support.