### PR TITLE
perf: reduce app memory footprint

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/WireGuardAutoTunnel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/WireGuardAutoTunnel.kt
@@ -1,12 +1,14 @@
 package com.zaneschepke.wireguardautotunnel
 
 import android.app.Application
+import android.content.ComponentCallbacks2
 import android.os.StrictMode
 import com.wgtunnel.backend.Backend
 import com.wgtunnel.backend.BackendLog
 import com.wgtunnel.backend.LogLevel
 import com.wgtunnel.backend.service.AlwaysOnCallback
 import com.wgtunnel.backend.service.RuntimeManager
+import com.zaneschepke.logcatter.LogReader
 import com.zaneschepke.wireguardautotunnel.core.event.TunnelEventDispatcher
 import com.zaneschepke.wireguardautotunnel.core.orchestration.AppBoostrapCoordinator
 import com.zaneschepke.wireguardautotunnel.core.orchestration.StartupCoordinator
@@ -119,6 +121,14 @@ class WireGuardAutoTunnel : Application(), KoinComponent {
 
         applicationScope.launch(ioDispatcher) {
             boostrapCoordinator.bootstrap(this@WireGuardAutoTunnel)
+        }
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        // numeric compare also covers the deprecated levels above background on older apis
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
+            applicationScope.launch { get<LogReader>().clearBufferedLogs() }
         }
     }
 

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/InstalledAndroidPackageRepository.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/InstalledAndroidPackageRepository.kt
@@ -14,6 +14,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,8 +33,10 @@ import timber.log.Timber
 class InstalledAndroidPackageRepository(
     private val context: Context,
     private val ioDispatcher: CoroutineDispatcher,
-    private val applicationScope: CoroutineScope,
-) : InstalledPackageRepository {
+) : InstalledPackageRepository, AutoCloseable {
+
+    // scoped to this instance so the receiver and cache are released with the owning scope
+    private val repositoryScope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     private val _installedPackages = MutableStateFlow<List<InstalledPackage>>(emptyList())
     override val installedPackages: StateFlow<List<InstalledPackage>> =
@@ -40,7 +44,7 @@ class InstalledAndroidPackageRepository(
 
     init {
         // warm the cache
-        applicationScope.launch(ioDispatcher) { refreshInstalledPackages() }
+        repositoryScope.launch { refreshInstalledPackages() }
 
         // watch for packages changes and update the cache
         callbackFlow {
@@ -74,7 +78,11 @@ class InstalledAndroidPackageRepository(
                 refreshInstalledPackages()
             }
             .flowOn(ioDispatcher)
-            .launchIn(applicationScope)
+            .launchIn(repositoryScope)
+    }
+
+    override fun close() {
+        repositoryScope.cancel()
     }
 
     override suspend fun getInstalledPackages(): List<InstalledPackage> =

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/di/DatabaseModule.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/di/DatabaseModule.kt
@@ -35,6 +35,7 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.dsl.onClose
 import org.koin.viewmodel.scope.viewModelScope
 
 @OptIn(KoinExperimentalAPI::class, KoinViewModelScopeApi::class)
@@ -79,11 +80,7 @@ val databaseModule = module {
     singleOf(::RoomTunnelRepository) bind TunnelRepository::class
     viewModelScope {
         scoped<InstalledPackageRepository> {
-            InstalledAndroidPackageRepository(
-                androidContext(),
-                get(named(Dispatcher.IO)),
-                get(named(Scope.APPLICATION)),
-            )
-        }
+            InstalledAndroidPackageRepository(androidContext(), get(named(Dispatcher.IO)))
+        } onClose { (it as? AutoCloseable)?.close() }
     }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/LoggerViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/LoggerViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.dokar.sonner.ToastType
 import com.zaneschepke.logcatter.LogReader
+import com.zaneschepke.logcatter.model.LogMessage
 import com.zaneschepke.wireguardautotunnel.BuildConfig
 import com.zaneschepke.wireguardautotunnel.R
 import com.zaneschepke.wireguardautotunnel.domain.repository.GlobalEffectRepository
@@ -16,7 +17,10 @@ import com.zaneschepke.wireguardautotunnel.util.extensions.toUserFriendlyTimesta
 import java.time.Instant
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.sample
 import org.orbitmvi.orbit.OrbitContainerHost
 import org.orbitmvi.orbit.viewmodel.orbitContainer
 
@@ -25,25 +29,28 @@ class LoggerViewModel(
     private val globalEffectRepository: GlobalEffectRepository,
 ) : OrbitContainerHost<LoggerUiState, LoggerUiState, Nothing>, ViewModel() {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    // accumulator shared between the producer and sampler coroutines of the batching pipeline
+    private val logBuffer = ArrayDeque<LogMessage>()
+
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     override val container =
         orbitContainer<LoggerUiState, Nothing>(
             LoggerUiState(),
             buildSettings = { repeatOnSubscribedStopTimeout = 5000L },
         ) {
             intent {
-                logReader.bufferedLogs.collect { logMessage ->
-                    reduce {
-                        state.copy(
-                            messages =
-                                state.messages.toMutableList().apply {
-                                    if (size >= MAX_LOG_SIZE) removeAt(0)
-                                    add(logMessage)
-                                },
-                            isLoading = false,
-                        )
+                logReader.bufferedLogs
+                    .onEach { logMessage ->
+                        synchronized(logBuffer) {
+                            if (logBuffer.size >= MAX_LOG_SIZE) logBuffer.removeFirst()
+                            logBuffer.addLast(logMessage)
+                        }
                     }
-                }
+                    .sample(BATCH_INTERVAL)
+                    .collect {
+                        val snapshot = synchronized(logBuffer) { logBuffer.toList() }
+                        reduce { state.copy(messages = snapshot, isLoading = false) }
+                    }
             }
             intent {
                 delay(300.milliseconds)
@@ -72,6 +79,7 @@ class LoggerViewModel(
     }
 
     fun deleteLogs() = intent {
+        synchronized(logBuffer) { logBuffer.clear() }
         reduce { state.copy(messages = emptyList()) }
         logReader.deleteAndClearLogs()
         postSideEffect(
@@ -84,5 +92,6 @@ class LoggerViewModel(
 
     companion object {
         const val MAX_LOG_SIZE = 10_000L
+        private val BATCH_INTERVAL = 200.milliseconds
     }
 }

--- a/logcatter/src/main/java/com/zaneschepke/logcatter/LogReader.kt
+++ b/logcatter/src/main/java/com/zaneschepke/logcatter/LogReader.kt
@@ -16,5 +16,4 @@ interface LogReader {
     suspend fun clearBufferedLogs()
 
     val bufferedLogs: Flow<LogMessage>
-    val liveLogs: Flow<LogMessage>
 }

--- a/logcatter/src/main/java/com/zaneschepke/logcatter/LogReader.kt
+++ b/logcatter/src/main/java/com/zaneschepke/logcatter/LogReader.kt
@@ -12,6 +12,9 @@ interface LogReader {
 
     suspend fun deleteAndClearLogs()
 
+    // clears the in-memory replay cache only, log files on disk are untouched
+    suspend fun clearBufferedLogs()
+
     val bufferedLogs: Flow<LogMessage>
     val liveLogs: Flow<LogMessage>
 }

--- a/logcatter/src/main/java/com/zaneschepke/logcatter/LogcatManager.kt
+++ b/logcatter/src/main/java/com/zaneschepke/logcatter/LogcatManager.kt
@@ -84,6 +84,11 @@ class LogcatManager(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun clearBufferedLogs() {
+        mutex.withLock { _bufferedLogs.resetReplayCache() }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun deleteAndClearLogs() {
         val wasStarted = mutex.withLock { isStarted }
         stop()

--- a/logcatter/src/main/java/com/zaneschepke/logcatter/LogcatManager.kt
+++ b/logcatter/src/main/java/com/zaneschepke/logcatter/LogcatManager.kt
@@ -35,21 +35,14 @@ class LogcatManager(
             replay = 10_000,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
-    private val _liveLogs =
-        MutableSharedFlow<LogMessage>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-
     override val bufferedLogs: Flow<LogMessage> = _bufferedLogs.asSharedFlow()
-    override val liveLogs: Flow<LogMessage> = _liveLogs.asSharedFlow()
 
     override suspend fun start() {
         mutex.withLock {
             if (isStarted) return
             stopInternal()
             logJob = logScope.launch {
-                logcatReader.readLogs().collect { logMessage ->
-                    _bufferedLogs.emit(logMessage)
-                    _liveLogs.emit(logMessage)
-                }
+                logcatReader.readLogs().collect { logMessage -> _bufferedLogs.emit(logMessage) }
             }
             isStarted = true
         }


### PR DESCRIPTION
## Motivation

The app process is designed to stay alive indefinitely (auto-tunnel foreground service + VpnService), which makes its background memory footprint exactly what Google Play's upcoming memory thresholds target (announced Aug 2026, enforced Feb 2027: dynamic memory usage, bitmap usage, DEX optimization), and what Android 17's per-app memory limits enforce (processes exceeding them are killed, showing `MemoryLimiter:AnonSwap` in `ApplicationExitInfo`). Going through the app with that lens turned up one real leak and a couple of avoidable retainers. Four focused changes, one commit each.

## Changes

**1. `fix`: broadcast receiver and package list leak on split tunnel screen revisits**

`InstalledAndroidPackageRepository` is Koin-scoped to the ViewModel (`viewModelScope { scoped { ... } }`), but its `init` launched the `PACKAGE_ADDED/REMOVED/REPLACED` receiver flow and the cache warm-up into the *application* scope. Since that scope never cancels, `awaitClose` never ran: every visit to the split tunneling screen leaked a registered `BroadcastReceiver` plus the full installed-package list, and each leaked receiver kept re-fetching the package list on every app install/uninstall on the device. The repository now owns a private scope cancelled through the Koin definition's `onClose` (invoked when the ViewModel is cleared), so the receiver and the cached list die with the screen.

**2. `perf`: batch logger state updates to avoid quadratic log list churn**

The logs screen collected `bufferedLogs` (replay = 10 000) one message at a time, doing `toMutableList()` + `removeAt(0)` per message inside a reduce. Opening the screen with a full buffer replayed 10k messages, i.e. ~10k list copies of up to 10k elements (O(n²)) and 10k state emissions — paid on every visit, since each visit creates a new ViewModel. Messages now accumulate in an `ArrayDeque` and the state receives immutable snapshots at most every 200 ms. UI behavior (live viewer, autoscroll) is unchanged, and `MAX_LOG_SIZE` stays at 10 000.

**3. `perf`: clear in-memory log buffer on background trim memory**

First `onTrimMemory` usage in the app. At `TRIM_MEMORY_BACKGROUND` and above, the 10k-message replay cache is dropped — it only serves the log viewer, while the log files on disk (which exports read from) are untouched. `TRIM_MEMORY_UI_HIDDEN` intentionally does nothing: after change 1 there is nothing cheap and significant left to free at that level. With local logging off (the default) this is a cheap no-op.

**4. `chore`: remove unused liveLogs api**

`LogReader.liveLogs` had no consumers; removing it also drops a second `MutableSharedFlow` and a duplicate emit per log line. Kept as a separate commit so it can be dropped easily if you'd rather keep the API.

## Verification (emulator, API 37)

- **Leak**: dynamic receiver count for the process was 16 at baseline, 18 while on the split tunneling screen, and back to 16 after leaving — across 3 consecutive visits (previously each visit would have permanently added one). LeakCanary stayed silent.
- **Trim**: `am send-trim-memory … HIDDEN` keeps the viewer scrollback; `… BACKGROUND` drops it — Java Heap went from 22.3 MB to 13.9 MB in `dumpsys meminfo`, and the oldest in-memory entry after reopening the viewer was timestamped 1 s after the trim. With local logging off: no-op, no crash.
- **Log viewer**: renders live with batched updates; log export still works after a trim (reads from disk).
- `./gradlew ktfmtCheck` passes; no new dependencies.
