### PR TITLE
feat: request notification permission and improve error notifications

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
@@ -86,6 +86,7 @@ import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
 import com.zaneschepke.wireguardautotunnel.domain.repository.AppStateRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.TunnelRepository
 import com.zaneschepke.wireguardautotunnel.domain.sideeffect.GlobalSideEffect
+import com.zaneschepke.wireguardautotunnel.domain.sideeffect.NotificationPendingAction
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.EXTRA_AUTO_UPDATE
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.EXTRA_OPEN_SUPPORT
@@ -226,6 +227,9 @@ class MainActivity : AppCompatActivity() {
             var requestingTunnelMode by remember {
                 mutableStateOf<Pair<TunnelMode?, TunnelConfig?>>(Pair(null, null))
             }
+            var pendingNotificationAction by remember {
+                mutableStateOf<NotificationPendingAction?>(null)
+            }
             var showLocalNetworkRationale by remember { mutableStateOf(false) }
             var hasPromptedLocalNetwork by rememberSaveable { mutableStateOf(false) }
 
@@ -328,6 +332,17 @@ class MainActivity : AppCompatActivity() {
                     },
                 )
 
+            val notificationPermissionLauncher =
+                rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+                    when (val action = pendingNotificationAction) {
+                        is NotificationPendingAction.StartTunnel ->
+                            viewModel.startTunnel(action.config)
+                        NotificationPendingAction.ToggleAutoTunnel -> viewModel.toggleAutoTunnel()
+                        null -> Unit
+                    }
+                    pendingNotificationAction = null
+                }
+
             LaunchedEffect(uiState.isAppLoaded, coldStartAutoUpdate) {
                 if (!uiState.isAppLoaded || !coldStartAutoUpdate) return@LaunchedEffect
                 coldStartAutoUpdate = false
@@ -354,6 +369,12 @@ class MainActivity : AppCompatActivity() {
                             requestingTunnelMode =
                                 Pair(sideEffect.requestingMode, sideEffect.config)
                             vpnActivity.launch(VpnService.prepare(this@MainActivity))
+                        }
+                        is GlobalSideEffect.RequestNotificationPermission -> {
+                            pendingNotificationAction = sideEffect.pendingAction
+                            notificationPermissionLauncher.launch(
+                                Manifest.permission.POST_NOTIFICATIONS
+                            )
                         }
                         is GlobalSideEffect.Snackbar -> snackbarChannel.send(sideEffect)
                         is GlobalSideEffect.LaunchUrl -> context.openWebUrl(sideEffect.url)

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/DataStoreManager.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/DataStoreManager.kt
@@ -26,6 +26,8 @@ class DataStoreManager(
     companion object {
         val locationDisclosureShown = booleanPreferencesKey("LOCATION_DISCLOSURE_SHOWN")
         val batteryDisableShown = booleanPreferencesKey("BATTERY_OPTIMIZE_DISABLE_SHOWN")
+        val notificationPermissionRequested =
+            booleanPreferencesKey("NOTIFICATION_PERMISSION_REQUESTED")
         val shouldShowDonationSnackbar = booleanPreferencesKey("SHOW_DONATION_SNACK")
         val lastActiveTunnelIds = stringPreferencesKey("LAST_ACTIVE_TUNNEL_IDS")
     }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/AppState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/AppState.kt
@@ -3,5 +3,6 @@ package com.zaneschepke.wireguardautotunnel.data.entity
 data class AppState(
     val isLocationDisclosureShown: Boolean = false,
     val isBatteryOptimizationDisableShown: Boolean = false,
+    val isNotificationPermissionRequested: Boolean = false,
     val shouldShowDonationSnackbar: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/GeneralStateMapper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/GeneralStateMapper.kt
@@ -7,5 +7,6 @@ fun Entity.toDomain(): Domain =
     Domain(
         isLocationDisclosureShown = isLocationDisclosureShown,
         isBatteryOptimizationDisableShown = isBatteryOptimizationDisableShown,
+        isNotificationPermissionRequested = isNotificationPermissionRequested,
         shouldShowDonationSnackbar = shouldShowDonationSnackbar,
     )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/DataStoreAppStateRepository.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/repository/DataStoreAppStateRepository.kt
@@ -35,6 +35,18 @@ class DataStoreAppStateRepository(
         dataStoreManager.saveToDataStore(DataStoreManager.batteryDisableShown, shown)
     }
 
+    override suspend fun isNotificationPermissionRequested(): Boolean {
+        return dataStoreManager.getFromStore(DataStoreManager.notificationPermissionRequested)
+            ?: false
+    }
+
+    override suspend fun setNotificationPermissionRequested(requested: Boolean) {
+        dataStoreManager.saveToDataStore(
+            DataStoreManager.notificationPermissionRequested,
+            requested,
+        )
+    }
+
     override suspend fun setShouldShowDonationSnackbar(show: Boolean) {
         dataStoreManager.saveToDataStore(DataStoreManager.shouldShowDonationSnackbar, show)
     }
@@ -74,6 +86,8 @@ class DataStoreAppStateRepository(
                                 pref[DataStoreManager.locationDisclosureShown] ?: false,
                             isBatteryOptimizationDisableShown =
                                 pref[DataStoreManager.batteryDisableShown] ?: false,
+                            isNotificationPermissionRequested =
+                                pref[DataStoreManager.notificationPermissionRequested] ?: false,
                             shouldShowDonationSnackbar =
                                 pref[DataStoreManager.shouldShowDonationSnackbar] ?: false,
                         )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/AppState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/AppState.kt
@@ -3,5 +3,6 @@ package com.zaneschepke.wireguardautotunnel.domain.model
 data class AppState(
     val isLocationDisclosureShown: Boolean = false,
     val isBatteryOptimizationDisableShown: Boolean = false,
+    val isNotificationPermissionRequested: Boolean = false,
     val shouldShowDonationSnackbar: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/repository/AppStateRepository.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/repository/AppStateRepository.kt
@@ -12,6 +12,10 @@ interface AppStateRepository {
 
     suspend fun setBatteryOptimizationDisableShown(shown: Boolean)
 
+    suspend fun isNotificationPermissionRequested(): Boolean
+
+    suspend fun setNotificationPermissionRequested(requested: Boolean)
+
     suspend fun setShouldShowDonationSnackbar(show: Boolean)
 
     suspend fun shouldShowDonationSnackbar(): Boolean

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/sideeffect/GlobalSideEffect.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/sideeffect/GlobalSideEffect.kt
@@ -35,5 +35,14 @@ sealed class GlobalSideEffect {
     data class RequestVpnPermission(val requestingMode: TunnelMode, val config: TunnelConfig?) :
         GlobalSideEffect()
 
+    data class RequestNotificationPermission(val pendingAction: NotificationPendingAction) :
+        GlobalSideEffect()
+
     data class InstallApk(val apk: File) : GlobalSideEffect()
+}
+
+sealed class NotificationPendingAction {
+    data class StartTunnel(val config: TunnelConfig) : NotificationPendingAction()
+
+    data object ToggleAutoTunnel : NotificationPendingAction()
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidNotificationService.kt
@@ -22,7 +22,6 @@ import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Comp
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.EXTRA_ID
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.EXTRA_OPEN_SUPPORT
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.UPDATE_AVAILABLE_NOTIFICATION_ID
-import com.zaneschepke.wireguardautotunnel.util.StringValue
 
 class AndroidNotificationService(override val context: Context) : NotificationService {
 
@@ -71,34 +70,6 @@ class AndroidNotificationService(override val context: Context) : NotificationSe
                 style?.let { setStyle(it) }
             }
             .build()
-    }
-
-    override fun createNotification(
-        channel: NotificationChannels,
-        title: StringValue,
-        subText: String?,
-        actions: Collection<Action>,
-        description: StringValue,
-        showTimestamp: Boolean,
-        onGoing: Boolean,
-        onlyAlertOnce: Boolean,
-        groupKey: String?,
-        isGroupSummary: Boolean,
-        style: NotificationCompat.Style?,
-    ): Notification {
-        return createNotification(
-            channel,
-            title.asString(context),
-            subText,
-            actions,
-            description.asString(context),
-            showTimestamp,
-            onGoing,
-            onlyAlertOnce,
-            groupKey,
-            isGroupSummary,
-            style,
-        )
     }
 
     override fun createNotificationAction(

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
@@ -5,11 +5,9 @@ import com.zaneschepke.wireguardautotunnel.R
 import com.zaneschepke.wireguardautotunnel.domain.enums.NotificationAction
 import com.zaneschepke.wireguardautotunnel.notification.AndroidNotificationService.NotificationChannels
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.PROXY_GROUP_KEY
-import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.PROXY_NOTIFICATION_ID
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.TUNNEL_ERROR_NOTIFICATION_ID
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.TUNNEL_MESSAGES_NOTIFICATION_ID
 import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.VPN_GROUP_KEY
-import com.zaneschepke.wireguardautotunnel.notification.NotificationService.Companion.VPN_NOTIFICATION_ID
 
 class AndroidTunnelNotificationService(private val notificationService: NotificationService) :
     TunnelNotificationService {
@@ -109,38 +107,6 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
             NotificationChannels.Tunnel.Proxy,
             PROXY_GROUP_KEY,
         )
-    }
-
-    override fun updateVpnPersistentNotification(
-        tunnelNotificationLines: Map<Int, TunnelNotificationLine>
-    ) {
-        if (tunnelNotificationLines.isEmpty()) {
-            notificationService.remove(VPN_NOTIFICATION_ID)
-            return
-        }
-        val notification =
-            createGroupNotification(
-                tunnelNotificationLines,
-                NotificationChannels.Tunnel.VPN,
-                VPN_GROUP_KEY,
-            )
-        notificationService.show(VPN_NOTIFICATION_ID, notification)
-    }
-
-    override fun updateProxyPersistentNotification(
-        tunnelNotificationLines: Map<Int, TunnelNotificationLine>
-    ) {
-        if (tunnelNotificationLines.isEmpty()) {
-            notificationService.remove(PROXY_NOTIFICATION_ID)
-            return
-        }
-        val notification =
-            createGroupNotification(
-                tunnelNotificationLines,
-                NotificationChannels.Tunnel.Proxy,
-                PROXY_GROUP_KEY,
-            )
-        notificationService.show(PROXY_NOTIFICATION_ID, notification)
     }
 
     override fun showIpv4Fallback(tunnelName: String) {

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
@@ -182,17 +182,17 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
     }
 
     override fun showSocks5PortUnavailable(port: Int, tunnelName: String) {
-        val context = notificationService.context
-        val message = context.getString(R.string.error_socks5_port_unavailable, port)
-
-        showError(message)
+        showErrorNotification(
+            title = "${context.getString(R.string.error)} • $tunnelName",
+            message = context.getString(R.string.error_socks5_port_unavailable, port),
+        )
     }
 
     override fun showHttpPortUnavailable(port: Int, tunnelName: String) {
-        val context = notificationService.context
-        val message = context.getString(R.string.error_http_port_unavailable, port)
-
-        showError(message)
+        showErrorNotification(
+            title = "${context.getString(R.string.error)} • $tunnelName",
+            message = context.getString(R.string.error_http_port_unavailable, port),
+        )
     }
 
     override fun showConfigMissingDns(tunnelName: String) {
@@ -202,10 +202,14 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
     }
 
     override fun showError(message: String) {
+        showErrorNotification(title = context.getString(R.string.error), message = message)
+    }
+
+    private fun showErrorNotification(title: String, message: String) {
         val notification =
             notificationService.createNotification(
                 channel = NotificationChannels.Errors,
-                title = notificationService.context.getString(R.string.error),
+                title = title,
                 description = message,
                 onGoing = false,
                 onlyAlertOnce = true,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
@@ -214,6 +214,7 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
                 onGoing = false,
                 onlyAlertOnce = true,
                 groupKey = VPN_GROUP_KEY,
+                style = NotificationCompat.BigTextStyle().bigText(message),
             )
 
         notificationService.show(TUNNEL_ERROR_NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/AndroidTunnelNotificationService.kt
@@ -213,7 +213,6 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
                 description = message,
                 onGoing = false,
                 onlyAlertOnce = true,
-                groupKey = VPN_GROUP_KEY,
                 style = NotificationCompat.BigTextStyle().bigText(message),
             )
 
@@ -221,7 +220,6 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
     }
 
     private fun showEvent(title: String, message: String) {
-
         val notification =
             notificationService.createNotification(
                 channel = NotificationChannels.Events,
@@ -229,7 +227,6 @@ class AndroidTunnelNotificationService(private val notificationService: Notifica
                 description = message,
                 onGoing = false,
                 onlyAlertOnce = true,
-                groupKey = VPN_GROUP_KEY,
             )
 
         notificationService.show(TUNNEL_MESSAGES_NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/NotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/NotificationService.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import com.zaneschepke.wireguardautotunnel.domain.enums.NotificationAction
 import com.zaneschepke.wireguardautotunnel.notification.AndroidNotificationService.NotificationChannels
-import com.zaneschepke.wireguardautotunnel.util.StringValue
 
 interface NotificationService {
     val context: Context
@@ -16,20 +15,6 @@ interface NotificationService {
         subText: String? = null,
         actions: Collection<NotificationCompat.Action> = emptyList(),
         description: String = "",
-        showTimestamp: Boolean = true,
-        onGoing: Boolean = false,
-        onlyAlertOnce: Boolean = true,
-        groupKey: String? = null,
-        isGroupSummary: Boolean = false,
-        style: NotificationCompat.Style? = null,
-    ): Notification
-
-    fun createNotification(
-        channel: NotificationChannels,
-        title: StringValue,
-        subText: String? = null,
-        actions: Collection<NotificationCompat.Action> = emptyList(),
-        description: StringValue,
         showTimestamp: Boolean = true,
         onGoing: Boolean = false,
         onlyAlertOnce: Boolean = true,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/TunnelNotificationService.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/notification/TunnelNotificationService.kt
@@ -4,10 +4,6 @@ import android.app.Notification
 
 interface TunnelNotificationService {
 
-    fun updateProxyPersistentNotification(tunnelNotificationLines: Map<Int, TunnelNotificationLine>)
-
-    fun updateVpnPersistentNotification(tunnelNotificationLines: Map<Int, TunnelNotificationLine>)
-
     fun buildVpnPersistentNotification(
         tunnelNotificationLines: Map<Int, TunnelNotificationLine>
     ): Notification

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/service/ServiceManager.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/service/ServiceManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 import com.zaneschepke.wireguardautotunnel.service.autotunnel.AutoTunnelService
+import com.zaneschepke.wireguardautotunnel.util.permission.NotificationPermissionHelper
 
 class ServiceManager(private val context: Context) {
 
@@ -17,5 +18,9 @@ class ServiceManager(private val context: Context) {
 
     fun hasVpnPermission(): Boolean {
         return VpnService.prepare(context) == null
+    }
+
+    fun hasNotificationPermission(): Boolean {
+        return NotificationPermissionHelper.isPermissionGranted(context)
     }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/permission/NotificationPermissionHelper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/permission/NotificationPermissionHelper.kt
@@ -1,0 +1,23 @@
+package com.zaneschepke.wireguardautotunnel.util.permission
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object NotificationPermissionHelper {
+
+    fun shouldRequestPermission(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    }
+
+    fun isPermissionGranted(context: Context): Boolean {
+        return if (shouldRequestPermission()) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+}

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/AutoTunnelViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/AutoTunnelViewModel.kt
@@ -11,10 +11,12 @@ import com.zaneschepke.wireguardautotunnel.core.orchestration.AutoTunnelCoordina
 import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelMode
 import com.zaneschepke.wireguardautotunnel.domain.enums.WifiDetectionMethod
 import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
+import com.zaneschepke.wireguardautotunnel.domain.repository.AppStateRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.AutoTunnelSettingsRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.GlobalEffectRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.TunnelRepository
 import com.zaneschepke.wireguardautotunnel.domain.sideeffect.GlobalSideEffect
+import com.zaneschepke.wireguardautotunnel.domain.sideeffect.NotificationPendingAction
 import com.zaneschepke.wireguardautotunnel.service.ServiceManager
 import com.zaneschepke.wireguardautotunnel.service.autotunnel.AutoTunnelStateHolder
 import com.zaneschepke.wireguardautotunnel.ui.screens.autotunnel.AutoTunnelScreenSideEffect
@@ -37,6 +39,7 @@ class AutoTunnelViewModel(
     private val autoTunnelCoordinator: AutoTunnelCoordinator,
     private val tunnelsRepository: TunnelRepository,
     private val autoTunnelStateHolder: AutoTunnelStateHolder,
+    private val appStateRepository: AppStateRepository,
 ) :
     OrbitContainerHost<AutoTunnelUiState, AutoTunnelUiState, AutoTunnelScreenSideEffect>,
     ViewModel() {
@@ -83,6 +86,17 @@ class AutoTunnelViewModel(
                         )
 
                 else -> Unit
+            }
+            if (
+                !serviceManager.hasNotificationPermission() &&
+                    !appStateRepository.isNotificationPermissionRequested()
+            ) {
+                appStateRepository.setNotificationPermissionRequested(true)
+                return@intent postSideEffect(
+                    GlobalSideEffect.RequestNotificationPermission(
+                        NotificationPendingAction.ToggleAutoTunnel
+                    )
+                )
             }
         }
         autoTunnelCoordinator.toggle()

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
@@ -7,6 +7,7 @@ import com.dokar.sonner.ToastType
 import com.wgtunnel.parser.Config
 import com.wgtunnel.parser.ConfigParseException
 import com.zaneschepke.wireguardautotunnel.R
+import com.zaneschepke.wireguardautotunnel.core.orchestration.AutoTunnelCoordinator
 import com.zaneschepke.wireguardautotunnel.core.orchestration.TunnelBackendCoordinator
 import com.zaneschepke.wireguardautotunnel.core.orchestration.TunnelCoordinator
 import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelMode
@@ -17,6 +18,7 @@ import com.zaneschepke.wireguardautotunnel.domain.repository.GlobalEffectReposit
 import com.zaneschepke.wireguardautotunnel.domain.repository.SelectedTunnelsRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.TunnelRepository
 import com.zaneschepke.wireguardautotunnel.domain.sideeffect.GlobalSideEffect
+import com.zaneschepke.wireguardautotunnel.domain.sideeffect.NotificationPendingAction
 import com.zaneschepke.wireguardautotunnel.service.ServiceManager
 import com.zaneschepke.wireguardautotunnel.service.autotunnel.AutoTunnelStateHolder
 import com.zaneschepke.wireguardautotunnel.ui.sideeffect.LocalSideEffect
@@ -62,6 +64,7 @@ class SharedAppViewModel(
     private val appStateRepository: AppStateRepository,
     private val serviceManager: ServiceManager,
     private val tunnelCoordinator: TunnelCoordinator,
+    private val autoTunnelCoordinator: AutoTunnelCoordinator,
     private val globalEffectRepository: GlobalEffectRepository,
     private val tunnelRepository: TunnelRepository,
     private val settingsRepository: GeneralSettingRepository,
@@ -151,8 +154,21 @@ class SharedAppViewModel(
                     GlobalSideEffect.RequestVpnPermission(TunnelMode.VPN, tunnelConfig)
                 )
         }
+        if (
+            !serviceManager.hasNotificationPermission() &&
+                !appStateRepository.isNotificationPermissionRequested()
+        ) {
+            appStateRepository.setNotificationPermissionRequested(true)
+            return@intent postSideEffect(
+                GlobalSideEffect.RequestNotificationPermission(
+                    NotificationPendingAction.StartTunnel(tunnelConfig)
+                )
+            )
+        }
         tunnelCoordinator.startTunnel(tunnelConfig)
     }
+
+    fun toggleAutoTunnel() = intent { autoTunnelCoordinator.toggle() }
 
     fun postSideEffect(localSideEffect: LocalSideEffect) = intent {
         postSideEffect(localSideEffect)


### PR DESCRIPTION
## Motivation

The app targets SDK 37 but never requests `POST_NOTIFICATIONS` at runtime. On Android 13+ notifications are off by default for fresh installs and the system shows no automatic prompt for apps targeting 33+, so `AndroidNotificationService.show()` silently drops every notification: tunnel errors (101), tunnel events (102), auto-tunnel location warnings (123/124), and the update notification (125) never appear, and the persistent tunnel notification only shows in the FGS Task Manager, never in the drawer.

While in there, a few small defects in the error/event notifications and some dead code. One commit each, independently droppable.

## Changes

**1. `feat`: request notification permission on first tunnel start**

In-context, one-time-ever prompt following the [notification permission guidance](https://developer.android.com/develop/ui/views/notifications/notification-permission): the request fires the first time the user starts a tunnel (any mode — proxy and lockdown also run a FGS and post events) or enables auto-tunnel, using the same stash-and-replay pattern as the existing VPN permission flow. A persisted flag (`NOTIFICATION_PERMISSION_REQUESTED`) is written before the side effect is posted, so the app asks the system at most once, ever — grant or deny, the pending action resumes either way and starting is never blocked. Denial is respected: no snackbar, no settings deep-link, no re-prompt.

Deliberately not a startup prompt: on Android 17+ the local network permission rationale already fires at startup (MainActivity), and stacking a second system dialog on cold start is exactly what the guidance advises against. On a pristine install the VPN consent and the notification prompt appear strictly sequentially, never stacked. Headless start paths (QS tiles, broadcasts, boot, always-on) call the coordinator directly and are unaffected.

New `NotificationPermissionHelper` mirrors `LocalNetworkPermissionHelper` (no-op below API 33), `ServiceManager.hasNotificationPermission()` sits next to `hasVpnPermission()`, and the flag follows the existing DataStore/AppState layering.

**2. `fix`: include tunnel name in port unavailable error notifications**

`showSocks5PortUnavailable`/`showHttpPortUnavailable` received `tunnelName` and ignored it. The error notification title now follows the same `"<label> • <name>"` pattern the event notifications already use (`Error • wg0`). Extracted a private `showErrorNotification(title, message)` that `showError` delegates to — the `TunnelNotificationService` interface is unchanged.

**3. `fix`: use big text style for error notifications**

Both port-unavailable strings contain an embedded `\n` and `InternalFailure` carries arbitrary backend text, but without a style `setContentText` collapses to a single truncated line. Errors now set `BigTextStyle` so the full message is readable when expanded; events keep the default (their messages are short single lines).

**4. `fix`: remove broken notification grouping from error and event notifications**

Error (101) and event (102) notifications set `groupKey = VPN_GROUP_KEY`, sharing a group with the persistent tunnel notification across three channels of mixed importance — and the group has no summary notification anywhere. Per the [grouping docs](https://developer.android.com/develop/ui/views/notifications/group) a group without a manually posted summary isn't valid, and each of these IDs only ever has one live notification, so grouping buys nothing. Dropped the group key; the system's own auto-grouping still applies at 4+ notifications. The persistent 100/103 notifications are posted by the backend via `startForeground` and are left untouched.

**5. `chore`: remove unused notification service code**

`updateVpnPersistentNotification`/`updateProxyPersistentNotification` have no callers (the backend posts the persistent notification itself through the `build*` variants in `AppProvider`), and the `createNotification(StringValue, ...)` overload has no call sites. Separate commit so it's trivial to drop if you'd rather keep any of it.

## Verification (emulator, API 37)

- **Fresh install, tunnel start**: VPN consent → replay → notification prompt (attributed via `wm_create_activity`: launched directly from MainActivity, no LeakCanary bridge activity — the debug build's LeakCanary also requests this permission, which is easy to mistake for the app's own prompt when testing) → grant → tunnel starts and the persistent notification (`VPN • <name>`) appears in the drawer.
- **Deny path**: tunnel starts anyway; flag persists; no re-prompt on later starts (verified across cold starts, and with the permission revoked afterwards — same silent behavior as today).
- **Auto-tunnel**: battery-optimization interception stays first; notification prompt fires on the next enable tap; auto-tunnel resumes after the dialog resolves (notification 122 present).
- **Error path, live**: SOCKS5 proxy with the bind port already occupied, tunnel started from the QS tile (app in background) → notification 101 shows `Error • <tunnel>` with `template=BigTextStyle`, full two-line message in `bigText`, and no app group key in the record (previously `groupKey=VPN_GROUP`).
- `:app:ktfmtCheckMain` and `:app:assembleFdroidDebug` pass; no new dependencies, no new strings.
