### PR TITLE
fix: sync in-app language with system per-app language settings

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
@@ -144,7 +144,6 @@ import com.zaneschepke.wireguardautotunnel.util.StringValue
 import com.zaneschepke.wireguardautotunnel.util.extensions.installApk
 import com.zaneschepke.wireguardautotunnel.util.extensions.isRunningOnTv
 import com.zaneschepke.wireguardautotunnel.util.extensions.openWebUrl
-import com.zaneschepke.wireguardautotunnel.util.extensions.restartApp
 import com.zaneschepke.wireguardautotunnel.util.permission.LocalNetworkPermissionHelper
 import com.zaneschepke.wireguardautotunnel.viewmodel.ConfigEditViewModel
 import com.zaneschepke.wireguardautotunnel.viewmodel.SharedAppViewModel
@@ -347,7 +346,6 @@ class MainActivity : AppCompatActivity() {
             LaunchedEffect(Unit) {
                 viewModel.globalSideEffect.collectLatest { sideEffect ->
                     when (sideEffect) {
-                        GlobalSideEffect.ConfigChanged -> restartApp()
                         GlobalSideEffect.PopBackStack -> navController.pop()
                         is GlobalSideEffect.RequestVpnPermission -> {
                             requestingTunnelMode =

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/MainActivity.kt
@@ -140,7 +140,6 @@ import com.zaneschepke.wireguardautotunnel.ui.theme.SilverTree
 import com.zaneschepke.wireguardautotunnel.ui.theme.Straw
 import com.zaneschepke.wireguardautotunnel.ui.theme.WireguardAutoTunnelTheme
 import com.zaneschepke.wireguardautotunnel.util.FileUtils
-import com.zaneschepke.wireguardautotunnel.util.LocaleUtil
 import com.zaneschepke.wireguardautotunnel.util.StringValue
 import com.zaneschepke.wireguardautotunnel.util.extensions.installApk
 import com.zaneschepke.wireguardautotunnel.util.extensions.isRunningOnTv
@@ -213,7 +212,7 @@ class MainActivity : AppCompatActivity() {
 
             LaunchedEffect(uiState.isAppLoaded) {
                 if (uiState.isAppLoaded) {
-                    uiState.locale.let { LocaleUtil.changeLocale(it) }
+                    viewModel.syncLocale()
                 }
             }
 

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/sideeffect/GlobalSideEffect.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/sideeffect/GlobalSideEffect.kt
@@ -21,8 +21,6 @@ sealed class GlobalSideEffect {
 
     data class LaunchUrl(val url: String) : GlobalSideEffect()
 
-    data object ConfigChanged : GlobalSideEffect()
-
     data class ExportFile(
         val uri: Uri?,
         val fileName: String,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/appearance/language/LanguageScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/appearance/language/LanguageScreen.kt
@@ -1,5 +1,6 @@
 package com.zaneschepke.wireguardautotunnel.ui.screens.settings.appearance.language
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,7 +11,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
@@ -21,12 +21,9 @@ import com.zaneschepke.wireguardautotunnel.util.LocaleUtil
 import com.zaneschepke.wireguardautotunnel.viewmodel.SharedAppViewModel
 import java.text.Collator
 import org.koin.compose.viewmodel.koinActivityViewModel
-import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
 fun LanguageScreen(sharedViewModel: SharedAppViewModel = koinActivityViewModel()) {
-
-    val appState by sharedViewModel.collectAsState()
 
     val collator = Collator.getInstance(Locale.current.platformLocale)
     val locales =
@@ -42,15 +39,21 @@ fun LanguageScreen(sharedViewModel: SharedAppViewModel = koinActivityViewModel()
 
     val lazyListState = rememberLazyListState()
 
-    val selectedIndex =
-        remember(appState.locale, sortedLocales) {
-            if (appState.locale == LocaleUtil.OPTION_PHONE_LANGUAGE) 0
-            else {
-                val selectedLocale = java.util.Locale.forLanguageTag(appState.locale)
-                sortedLocales.indexOfFirst {
-                    it.toLanguageTag() == selectedLocale.toLanguageTag()
-                } + 1
+    val currentLocale = AppCompatDelegate.getApplicationLocales().get(0)
+
+    val selectedTag =
+        remember(currentLocale, sortedLocales) {
+            currentLocale?.let { current ->
+                (sortedLocales.firstOrNull { it.toLanguageTag() == current.toLanguageTag() }
+                        ?: sortedLocales.firstOrNull { it.language == current.language })
+                    ?.toLanguageTag()
             }
+        }
+
+    val selectedIndex =
+        remember(selectedTag, sortedLocales) {
+            if (selectedTag == null) 0
+            else sortedLocales.indexOfFirst { it.toLanguageTag() == selectedTag } + 1
         }
 
     LaunchedEffect(selectedIndex) {
@@ -68,7 +71,7 @@ fun LanguageScreen(sharedViewModel: SharedAppViewModel = koinActivityViewModel()
             SurfaceRow(
                 title = stringResource(R.string.automatic),
                 trailing =
-                    if (appState.locale == LocaleUtil.OPTION_PHONE_LANGUAGE) {
+                    if (currentLocale == null) {
                         {
                             Icon(
                                 Icons.Outlined.Check,
@@ -88,7 +91,7 @@ fun LanguageScreen(sharedViewModel: SharedAppViewModel = koinActivityViewModel()
             SurfaceRow(
                 title = buttonText,
                 trailing =
-                    if (appState.locale == locale.toLanguageTag()) {
+                    if (selectedTag == locale.toLanguageTag()) {
                         {
                             Icon(
                                 Icons.Outlined.Check,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/state/GlobalAppUiState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/state/GlobalAppUiState.kt
@@ -2,12 +2,10 @@ package com.zaneschepke.wireguardautotunnel.ui.state
 
 import com.zaneschepke.wireguardautotunnel.domain.enums.TunnelMode
 import com.zaneschepke.wireguardautotunnel.ui.theme.Theme
-import com.zaneschepke.wireguardautotunnel.util.LocaleUtil
 
 data class GlobalAppUiState(
     val isAppLoaded: Boolean = false,
     val theme: Theme = Theme.AUTOMATIC,
-    val locale: String = LocaleUtil.OPTION_PHONE_LANGUAGE,
     val pinLockEnabled: Boolean = false,
     val tunnelMode: TunnelMode = TunnelMode.VPN,
     val shouldShowDonationSnackbar: Boolean = false,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/LocaleUtil.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/LocaleUtil.kt
@@ -1,5 +1,6 @@
 package com.zaneschepke.wireguardautotunnel.util
 
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.zaneschepke.wireguardautotunnel.BuildConfig
@@ -7,6 +8,10 @@ import com.zaneschepke.wireguardautotunnel.BuildConfig
 object LocaleUtil {
     val supportedLocales: Array<String> = BuildConfig.LANGUAGES
     const val OPTION_PHONE_LANGUAGE = "sys_def"
+
+    // Android 13+ persists per-app locales and exposes them in system settings
+    val isSystemManaged: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 
     fun changeLocale(locale: String) {
         if (locale == OPTION_PHONE_LANGUAGE) return resetToSystemLanguage()

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/ContextExtensions.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/ContextExtensions.kt
@@ -11,14 +11,12 @@ import android.provider.Settings
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import com.zaneschepke.wireguardautotunnel.BuildConfig
-import com.zaneschepke.wireguardautotunnel.MainActivity
 import com.zaneschepke.wireguardautotunnel.R
 import com.zaneschepke.wireguardautotunnel.util.Constants
 import com.zaneschepke.wireguardautotunnel.util.FileUtils
 import java.io.File
 import java.io.InputStream
 import java.util.Locale
-import kotlin.system.exitProcess
 import timber.log.Timber
 
 fun Context.openWebUrl(url: String): Result<Unit> = runCatching {
@@ -196,13 +194,6 @@ fun Context.launchPlayStoreReview(): Result<Unit> = runCatching {
 
 fun Activity.setScreenBrightness(brightness: Float) {
     window.attributes = window.attributes.apply { screenBrightness = brightness }
-}
-
-fun MainActivity.restartApp() {
-    Intent(this, MainActivity::class.java).also {
-        startActivity(it)
-        exitProcess(0)
-    }
 }
 
 fun PackageManager.getFriendlyAppName(packageName: String, appInfo: ApplicationInfo): String {

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
@@ -127,7 +127,6 @@ class SharedAppViewModel(
                         state.copy(
                             theme = settings.theme,
                             tunnelMode = settings.tunnelMode,
-                            locale = settings.locale ?: LocaleUtil.OPTION_PHONE_LANGUAGE,
                             tunnelNames = tunNames,
                             alreadyDonated = settings.alreadyDonated,
                             isAutoTunnelActive = autoTunnelActive,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SharedAppViewModel.kt
@@ -1,6 +1,7 @@
 package com.zaneschepke.wireguardautotunnel.viewmodel
 
 import android.net.Uri
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dokar.sonner.ToastType
@@ -165,8 +166,23 @@ class SharedAppViewModel(
     fun setTheme(theme: Theme) = intent { settingsRepository.updateTheme(theme) }
 
     fun setLocale(locale: String) = intent {
-        settingsRepository.updateLocale(locale)
-        postSideEffect(GlobalSideEffect.ConfigChanged)
+        // pre-T the stored value is reapplied on startup, on T+ the system persists it
+        if (!LocaleUtil.isSystemManaged) settingsRepository.updateLocale(locale)
+        withContext(Dispatchers.Main) { LocaleUtil.changeLocale(locale) }
+    }
+
+    fun syncLocale() = intent {
+        val stored = settingsRepository.flow.firstOrNull()?.locale ?: return@intent
+        if (stored == LocaleUtil.OPTION_PHONE_LANGUAGE) return@intent
+        if (LocaleUtil.isSystemManaged) {
+            // one-time handoff to the system, without overriding a locale set in system settings
+            if (AppCompatDelegate.getApplicationLocales().isEmpty) {
+                withContext(Dispatchers.Main) { LocaleUtil.changeLocale(stored) }
+            }
+            settingsRepository.updateLocale(LocaleUtil.OPTION_PHONE_LANGUAGE)
+        } else {
+            withContext(Dispatchers.Main) { LocaleUtil.changeLocale(stored) }
+        }
     }
 
     fun setPinLockEnabled(enabled: Boolean) = intent {


### PR DESCRIPTION
### Repro

1. Set a language for the app under System Settings → App info → Language (the app appears there since it ships `generateLocaleConfig`).
2. Open the app.

The system choice is ignored: the app renders in the system default language and the per-app locale is silently reset to `[]` (`adb shell cmd locale get-app-locales` confirms it).

### Cause

The locale stored in Room is re-applied on every startup. With the default `sys_def` value this calls `setApplicationLocales(emptyLocaleList)`, wiping whatever the user set in system settings. The in-app picker also read its selection from Room, so both sides could disagree even when the applied language was correct.

### Fix

- **Android 13+**: the framework is the single source of truth. Nothing is re-applied on startup; a one-shot migration hands any legacy stored value to the system (only when none is set there) and then clears it, so backups/old data can't resurrect a stale choice. The in-app picker no longer writes the DB and reads its selection from `AppCompatDelegate.getApplicationLocales()`.
- **Pre-T**: there are no system per-app locales to conflict with, so the stored value is kept and re-applied at startup, same behavior as before.

`autoStoreLocales` was deliberately not used: AppCompat 1.8.0's one-time `syncLocalesToFramework` clears an existing system-set per-app locale on the first launch after install/update (reproduced consistently on API 37 — the `getApplicationLocales().isEmpty()` guard in `AppCompatDelegate` doesn't hold in practice).

The second commit removes plumbing this leaves dead: language changes no longer restart the whole process (`ConfigChanged` side effect + `restartApp()` with `exitProcess`), the activity recreation triggered by `setApplicationLocales` is enough.

### Tested (emulator, API 37, clean install)

- System settings → Spanish: app opens in Spanish, picker marks Español, per-app locale survives restarts.
- Picker → Deutsch: app switches, system settings now show German.
- Picker → Automatic: back to system language, per-app locale cleared.
- Legacy migration: DB with `locale='es'` and no system value → applied and handed off on first launch, DB self-clears, second launch stable.
